### PR TITLE
feat: add /dice multiplayer dice game with Telegram dice stickers

### DIFF
--- a/bot/application/dice_service.py
+++ b/bot/application/dice_service.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from bot.application.interfaces.dice_repository import IDiceRepository
+from bot.application.interfaces.score_repository import IScoreRepository
+from bot.domain.dice_entities import DiceGame, DiceGameStatus
+
+
+@dataclass
+class CreateResult:
+    game: DiceGame | None
+    not_enough: bool = False
+    already_active: bool = False
+
+
+@dataclass
+class JoinResult:
+    success: bool
+    already_joined: bool = False
+    not_enough: bool = False
+    game_not_found: bool = False
+    balance: int = 0
+
+
+@dataclass
+class FinishResult:
+    game: DiceGame
+    participants: list[int]
+    dice_results: dict[int, int]         # user_id -> dice_value
+    winners: list[int]                   # user_ids с максимальным значением
+    prize_per_winner: int
+    total_pot: int
+
+
+class DiceService:
+    def __init__(
+        self,
+        dice_repo: IDiceRepository,
+        score_repo: IScoreRepository,
+    ) -> None:
+        self._dice_repo = dice_repo
+        self._score_repo = score_repo
+
+    async def create(
+        self,
+        chat_id: int,
+        created_by: int,
+        bet: int,
+        ends_at: datetime,
+    ) -> CreateResult:
+        """Создаёт игру и списывает ставку с создателя."""
+        # Только одна активная игра в чате
+        existing = await self._dice_repo.get_pending_in_chat(chat_id)
+        if existing is not None:
+            return CreateResult(game=None, already_active=True)
+
+        score = await self._score_repo.get(created_by, chat_id)
+        balance = score.value if score else 0
+        if balance < bet:
+            return CreateResult(game=None, not_enough=True)
+
+        game = DiceGame(chat_id=chat_id, bet=bet, ends_at=ends_at, created_by=created_by)
+        game = await self._dice_repo.create(game)
+        await self._score_repo.add_delta(created_by, chat_id, -bet)
+        await self._dice_repo.add_participant(game.id, created_by)  # type: ignore[arg-type]
+        return CreateResult(game=game)
+
+    async def set_message_id(self, game_id: int, message_id: int) -> None:
+        await self._dice_repo.update_message_id(game_id, message_id)
+
+    async def get_pending_in_chat(self, chat_id: int) -> DiceGame | None:
+        return await self._dice_repo.get_pending_in_chat(chat_id)
+
+    async def join(self, game_id: int, user_id: int) -> JoinResult:
+        """Участник присоединяется к игре. Списывает ставку."""
+        game = await self._dice_repo.get(game_id)
+        if game is None or game.status != DiceGameStatus.PENDING:
+            return JoinResult(success=False, game_not_found=True)
+
+        participants = await self._dice_repo.get_participants(game_id)
+        if user_id in participants:
+            return JoinResult(success=False, already_joined=True)
+
+        score = await self._score_repo.get(user_id, game.chat_id)
+        balance = score.value if score else 0
+        if balance < game.bet:
+            return JoinResult(success=False, not_enough=True, balance=balance)
+
+        await self._dice_repo.add_participant(game_id, user_id)
+        await self._score_repo.add_delta(user_id, game.chat_id, -game.bet)
+        return JoinResult(success=True)
+
+    async def count_participants(self, game_id: int) -> int:
+        return await self._dice_repo.count_participants(game_id)
+
+    async def finish(self, game_id: int, dice_results: dict[int, int]) -> FinishResult | None:
+        """Завершает игру с уже известными значениями костей. Распределяет призы."""
+        game = await self._dice_repo.get(game_id)
+        if game is None or game.status != DiceGameStatus.PENDING:
+            return None
+
+        participants = await self._dice_repo.get_participants(game_id)
+        total_pot = game.bet * len(participants)
+
+        if not participants or not dice_results:
+            # Нет участников — возврат ставок (не должно случаться)
+            for uid in participants:
+                await self._score_repo.add_delta(uid, game.chat_id, game.bet)
+            await self._dice_repo.finish(game_id)
+            return FinishResult(
+                game=game,
+                participants=participants,
+                dice_results={},
+                winners=participants,
+                prize_per_winner=game.bet,
+                total_pot=total_pot,
+            )
+
+        max_value = max(dice_results.values())
+        winners = [uid for uid, val in dice_results.items() if val == max_value]
+        prize_per_winner = total_pot // len(winners)
+        remainder = total_pot - prize_per_winner * len(winners)
+
+        for winner_id in winners:
+            await self._score_repo.add_delta(winner_id, game.chat_id, prize_per_winner)
+        # Остаток (при нечётном делении) — первому победителю
+        if remainder > 0:
+            await self._score_repo.add_delta(winners[0], game.chat_id, remainder)
+
+        await self._dice_repo.finish(game_id)
+        return FinishResult(
+            game=game,
+            participants=participants,
+            dice_results=dice_results,
+            winners=winners,
+            prize_per_winner=prize_per_winner,
+            total_pot=total_pot,
+        )
+
+    async def get_participants(self, game_id: int) -> list[int]:
+        return await self._dice_repo.get_participants(game_id)
+
+    async def get_expired(self, now: datetime) -> list[DiceGame]:
+        """Возвращает игры, у которых истёкло время сбора участников."""
+        return await self._dice_repo.get_expired(now)

--- a/bot/application/interfaces/dice_repository.py
+++ b/bot/application/interfaces/dice_repository.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from bot.domain.dice_entities import DiceGame
+
+
+class IDiceRepository(ABC):
+    @abstractmethod
+    async def create(self, game: DiceGame) -> DiceGame:
+        """Создаёт игру, возвращает с заполненным id."""
+        ...
+
+    @abstractmethod
+    async def update_message_id(self, game_id: int, message_id: int) -> None:
+        """Сохраняет id сообщения-анонса."""
+        ...
+
+    @abstractmethod
+    async def get(self, game_id: int) -> DiceGame | None: ...
+
+    @abstractmethod
+    async def get_pending_in_chat(self, chat_id: int) -> DiceGame | None:
+        """Возвращает активную (pending) игру в чате, или None."""
+        ...
+
+    @abstractmethod
+    async def finish(self, game_id: int) -> None:
+        """Переводит статус в finished."""
+        ...
+
+    @abstractmethod
+    async def get_expired(self, now: datetime) -> list[DiceGame]:
+        """Возвращает игры со статусом pending и ends_at <= now."""
+        ...
+
+    @abstractmethod
+    async def add_participant(self, game_id: int, user_id: int) -> bool:
+        """Добавляет участника. Возвращает False если уже участвует."""
+        ...
+
+    @abstractmethod
+    async def get_participants(self, game_id: int) -> list[int]:
+        """Список user_id всех участников."""
+        ...
+
+    @abstractmethod
+    async def count_participants(self, game_id: int) -> int: ...

--- a/bot/domain/dice_entities.py
+++ b/bot/domain/dice_entities.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class DiceGameStatus(str, Enum):
+    PENDING = "pending"
+    FINISHED = "finished"
+
+
+@dataclass
+class DiceGame:
+    chat_id: int
+    bet: int
+    ends_at: datetime
+    created_by: int
+    id: int | None = None
+    message_id: int | None = None
+    status: DiceGameStatus = DiceGameStatus.PENDING
+    created_at: datetime | None = None

--- a/bot/infrastructure/config_loader.py
+++ b/bot/infrastructure/config_loader.py
@@ -88,6 +88,14 @@ class BlackjackConfig:
 
 
 @dataclass
+class DiceConfig:
+    min_bet: int = 1
+    max_bet: int = 1000
+    min_wait_seconds: int = 10
+    max_wait_seconds: int = 3600  # 1 час
+
+
+@dataclass
 class SystemConfig:
     """Системные интервалы и технические параметры."""
 
@@ -146,6 +154,7 @@ class AppConfig:
     auto_react: AutoReactConfig = field(default_factory=AutoReactConfig)
     tag: TagConfig = field(default_factory=TagConfig)
     blackjack: BlackjackConfig = field(default_factory=BlackjackConfig)
+    dice: DiceConfig = field(default_factory=DiceConfig)
     llm: LlmConfig = field(default_factory=LlmConfig)
     system: SystemConfig = field(default_factory=SystemConfig)
 
@@ -173,6 +182,7 @@ def load_config(path: str | Path | None = None) -> AppConfig:
         auto_react=AutoReactConfig(**raw.get("auto_react", {})),
         tag=TagConfig(**raw.get("tag", {})),
         blackjack=BlackjackConfig(**blackjack_raw),
+        dice=DiceConfig(**raw.get("dice", {})),
         llm=LlmConfig(**raw.get("llm", {})),
         system=SystemConfig(**system_raw),
     )

--- a/bot/infrastructure/db/postgres_dice_repository.py
+++ b/bot/infrastructure/db/postgres_dice_repository.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import asyncpg
+
+from bot.application.interfaces.dice_repository import IDiceRepository
+from bot.domain.dice_entities import DiceGame, DiceGameStatus
+
+
+class PostgresDiceRepository(IDiceRepository):
+    def __init__(self, conn: asyncpg.Connection) -> None:
+        self._conn = conn
+
+    async def create(self, game: DiceGame) -> DiceGame:
+        row = await self._conn.fetchrow(
+            """
+            INSERT INTO dice_games (chat_id, bet, ends_at, created_by)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, created_at
+            """,
+            game.chat_id,
+            game.bet,
+            game.ends_at,
+            game.created_by,
+        )
+        game.id = row["id"]
+        game.created_at = row["created_at"]
+        return game
+
+    async def update_message_id(self, game_id: int, message_id: int) -> None:
+        await self._conn.execute(
+            "UPDATE dice_games SET message_id = $1 WHERE id = $2",
+            message_id,
+            game_id,
+        )
+
+    async def get(self, game_id: int) -> DiceGame | None:
+        row = await self._conn.fetchrow(
+            "SELECT * FROM dice_games WHERE id = $1",
+            game_id,
+        )
+        return self._row_to_game(row) if row else None
+
+    async def get_pending_in_chat(self, chat_id: int) -> DiceGame | None:
+        row = await self._conn.fetchrow(
+            "SELECT * FROM dice_games WHERE chat_id = $1 AND status = 'pending' LIMIT 1",
+            chat_id,
+        )
+        return self._row_to_game(row) if row else None
+
+    async def finish(self, game_id: int) -> None:
+        await self._conn.execute(
+            "UPDATE dice_games SET status = 'finished' WHERE id = $1",
+            game_id,
+        )
+
+    async def get_expired(self, now: datetime) -> list[DiceGame]:
+        rows = await self._conn.fetch(
+            """
+            SELECT * FROM dice_games
+            WHERE status = 'pending' AND ends_at <= $1
+            """,
+            now,
+        )
+        return [self._row_to_game(r) for r in rows]
+
+    async def add_participant(self, game_id: int, user_id: int) -> bool:
+        try:
+            await self._conn.execute(
+                """
+                INSERT INTO dice_participants (game_id, user_id)
+                VALUES ($1, $2)
+                """,
+                game_id,
+                user_id,
+            )
+            return True
+        except asyncpg.UniqueViolationError:
+            return False
+
+    async def get_participants(self, game_id: int) -> list[int]:
+        rows = await self._conn.fetch(
+            "SELECT user_id FROM dice_participants WHERE game_id = $1",
+            game_id,
+        )
+        return [r["user_id"] for r in rows]
+
+    async def count_participants(self, game_id: int) -> int:
+        row = await self._conn.fetchrow(
+            "SELECT COUNT(*) AS cnt FROM dice_participants WHERE game_id = $1",
+            game_id,
+        )
+        return row["cnt"] if row else 0
+
+    @staticmethod
+    def _row_to_game(row: asyncpg.Record) -> DiceGame:
+        return DiceGame(
+            id=row["id"],
+            chat_id=row["chat_id"],
+            bet=row["bet"],
+            status=DiceGameStatus(row["status"]),
+            message_id=row["message_id"],
+            ends_at=row["ends_at"],
+            created_by=row["created_by"],
+            created_at=row["created_at"],
+        )

--- a/bot/infrastructure/di.py
+++ b/bot/infrastructure/di.py
@@ -5,9 +5,11 @@ import redis.asyncio as aioredis
 from dishka import Provider, Scope, provide
 
 from bot.application.cleanup_service import CleanupService
+from bot.application.dice_service import DiceService
 from bot.application.giveaway_service import GiveawayService
 from bot.application.history_service import HistoryService
 from bot.application.interfaces.daily_limits_repository import IDailyLimitsRepository
+from bot.application.interfaces.dice_repository import IDiceRepository
 from bot.application.interfaces.event_repository import IEventRepository
 from bot.application.interfaces.giveaway_repository import IGiveawayRepository
 from bot.application.interfaces.llm_repository import ILlmRepository
@@ -30,6 +32,7 @@ from bot.infrastructure.aitunnel_client import AiTunnelClient
 from bot.infrastructure.config_loader import AppConfig, Settings, load_config, load_help_config, load_messages
 from bot.infrastructure.db.postgres_daily_limits_repository import PostgresDailyLimitsRepository
 from bot.infrastructure.db.postgres_event_repository import PostgresEventRepository
+from bot.infrastructure.db.postgres_dice_repository import PostgresDiceRepository
 from bot.infrastructure.db.postgres_giveaway_repository import PostgresGiveawayRepository
 from bot.infrastructure.db.postgres_llm_repository import PostgresLlmRepository
 from bot.infrastructure.db.postgres_message_repository import PostgresMessageRepository
@@ -160,6 +163,10 @@ class RequestProvider(Provider):
         return PostgresMuteProtectionRepository(tm.get_connection())
 
     @provide
+    def get_dice_repo(self, tm: ITransactionManager) -> IDiceRepository:
+        return PostgresDiceRepository(tm.get_connection())
+
+    @provide
     def get_giveaway_repo(self, tm: ITransactionManager) -> IGiveawayRepository:
         return PostgresGiveawayRepository(tm.get_connection())
 
@@ -204,6 +211,10 @@ class RequestProvider(Provider):
     @provide
     def get_mute_service(self, mute_repo: IMuteRepository) -> MuteService:
         return MuteService(mute_repo)
+
+    @provide
+    def get_dice_service(self, dice_repo: IDiceRepository, score_repo: IScoreRepository) -> DiceService:
+        return DiceService(dice_repo, score_repo)
 
     @provide
     def get_giveaway_service(self, repo: IGiveawayRepository, score_repo: IScoreRepository) -> GiveawayService:

--- a/bot/infrastructure/dice_loop.py
+++ b/bot/infrastructure/dice_loop.py
@@ -1,0 +1,138 @@
+"""Фоновая задача: бросает кости за участников по истечении времени сбора."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+
+from aiogram import Bot
+
+from bot.domain.tz import TZ_MSK
+
+logger = logging.getLogger(__name__)
+
+_DICE_EMOJI = "🎲"
+
+
+async def dice_loop(bot: Bot, container) -> None:
+    """Каждые 5 секунд проверяет и завершает просроченные игры в кости."""
+    from bot.application.dice_service import DiceService
+
+    while True:
+        await asyncio.sleep(5)
+        try:
+            async with container() as scope:
+                service: DiceService = await scope.get(DiceService)
+                expired = await service.get_expired(datetime.now(TZ_MSK))
+
+            for game in expired:
+                logger.info("Auto-finishing dice game %d in chat %d", game.id, game.chat_id)
+                await _resolve_game(bot, game, container)
+        except Exception:
+            logger.exception("Error in dice_loop")
+
+
+async def _resolve_game(bot: Bot, game, container) -> None:
+    """Бросает кости за каждого участника, распределяет приз."""
+    from bot.application.dice_service import DiceService
+    from bot.domain.pluralizer import ScorePluralizer
+
+    # Получаем список участников до броска
+    async with container() as scope:
+        service: DiceService = await scope.get(DiceService)
+        participants = await service.get_participants(game.id)
+
+    if not participants:
+        async with container() as scope:
+            service = await scope.get(DiceService)
+            await service.finish(game.id, {})
+        await bot.send_message(game.chat_id, "🎲 Игра в кости отменена: нет участников.")
+        await _remove_join_button(bot, game.chat_id, game.message_id)
+        return
+
+    # Бросаем кости за каждого участника
+    dice_results: dict[int, int] = {}
+
+    await bot.send_message(game.chat_id, "🎲 Бросаем кости!")
+
+    for user_id in participants:
+        try:
+            msg = await bot.send_dice(chat_id=game.chat_id, emoji=_DICE_EMOJI)
+            dice_results[user_id] = msg.dice.value  # type: ignore[union-attr]
+            await asyncio.sleep(0.5)
+        except Exception:
+            logger.warning("Failed to send dice for user %d in game %d", user_id, game.id)
+
+    # Завершаем игру и распределяем призы
+    async with container() as scope:
+        service = await scope.get(DiceService)
+        pluralizer: ScorePluralizer = await scope.get(ScorePluralizer)
+        result = await service.finish(game.id, dice_results)
+
+    if result is None:
+        logger.warning("Game %d already finished when trying to resolve", game.id)
+        return
+
+    await _post_dice_results(bot, result, pluralizer)
+    await _remove_join_button(bot, game.chat_id, game.message_id)
+
+
+async def _post_dice_results(bot: Bot, result, pluralizer) -> None:
+    """Публикует итоговое сообщение с результатами игры."""
+    chat_id = result.game.chat_id
+    participants_count = len(result.participants)
+
+    lines = [f"🎲 <b>Итоги игры в кости!</b> Участников: {participants_count}\n"]
+
+    # Результаты бросков
+    for user_id in result.participants:
+        value = result.dice_results.get(user_id, "?")
+        is_winner = user_id in result.winners
+        crown = " 👑" if is_winner else ""
+        try:
+            member = await bot.get_chat_member(chat_id, user_id)
+            name = f'<a href="tg://user?id={user_id}">{member.user.full_name}</a>'
+        except Exception:
+            name = f"<code>{user_id}</code>"
+        lines.append(f"• {name}: {value}{crown}")
+
+    lines.append("")
+
+    score_word = pluralizer.pluralize(result.prize_per_winner)
+    if len(result.winners) == 1:
+        winner_id = result.winners[0]
+        try:
+            member = await bot.get_chat_member(chat_id, winner_id)
+            winner_name = f'<a href="tg://user?id={winner_id}">{member.user.full_name}</a>'
+        except Exception:
+            winner_name = f"<code>{winner_id}</code>"
+        lines.append(f"🏆 {winner_name} выигрывает <b>{result.prize_per_winner} {score_word}</b>!")
+    else:
+        winner_mentions = []
+        for uid in result.winners:
+            try:
+                member = await bot.get_chat_member(chat_id, uid)
+                winner_mentions.append(f'<a href="tg://user?id={uid}">{member.user.full_name}</a>')
+            except Exception:
+                winner_mentions.append(f"<code>{uid}</code>")
+        winners_str = ", ".join(winner_mentions)
+        lines.append(
+            f"🏆 Победители: {winners_str}\n"
+            f"💰 Приз: <b>{result.prize_per_winner} {score_word}</b> каждому"
+        )
+
+    await bot.send_message(chat_id, "\n".join(lines), parse_mode="HTML")
+
+
+async def _remove_join_button(bot: Bot, chat_id: int, message_id: int | None) -> None:
+    if not message_id:
+        return
+    try:
+        await bot.edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=None,
+        )
+    except Exception:
+        pass

--- a/bot/main.py
+++ b/bot/main.py
@@ -8,10 +8,12 @@ from dishka.integrations.aiogram import setup_dishka
 
 from bot.infrastructure.config_loader import Settings, load_config
 from bot.infrastructure.di import AppProvider, RequestProvider
+from bot.infrastructure.dice_loop import dice_loop
 from bot.infrastructure.giveaway_loop import giveaway_loop
 from bot.presentation.handlers.admin_commands import _unmute_user, create_admin_router
 from bot.presentation.handlers.blackjack import router as blackjack_router
 from bot.presentation.handlers.commands import router as commands_router
+from bot.presentation.handlers.dice import router as dice_router
 from bot.presentation.handlers.giveaway import router as giveaway_router
 from bot.presentation.handlers.llm_commands import router as llm_router
 from bot.presentation.handlers.reactions import router as reactions_router
@@ -125,6 +127,7 @@ async def main() -> None:
 
     dp.include_router(commands_router)
     dp.include_router(blackjack_router)
+    dp.include_router(dice_router)
     dp.include_router(llm_router)
     dp.include_router(reactions_router)
     dp.include_router(slots_router)
@@ -145,6 +148,7 @@ async def main() -> None:
     cleanup_task = asyncio.create_task(cleanup_loop(container, sys_cfg.cleanup_interval_hours))
     unmute_task = asyncio.create_task(unmute_loop(container, bot, sys_cfg.unmute_check_interval_seconds))
     asyncio.create_task(giveaway_loop(bot, container))
+    asyncio.create_task(dice_loop(bot, container))
     mute_roulette_task = asyncio.create_task(mute_roulette_loop(container, bot))
 
     logger.info("Bot starting…")

--- a/bot/presentation/handlers/dice.py
+++ b/bot/presentation/handlers/dice.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import logging
+
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.types import (
+    CallbackQuery,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+)
+from dishka.integrations.aiogram import FromDishka, inject
+
+from bot.application.dice_service import DiceService
+from bot.application.interfaces.user_repository import IUserRepository
+from bot.domain.bot_utils import format_duration, parse_duration
+from bot.domain.entities import User
+from bot.domain.pluralizer import ScorePluralizer
+from bot.domain.tz import TZ_MSK
+from bot.infrastructure.config_loader import AppConfig
+
+logger = logging.getLogger(__name__)
+
+router = Router(name="dice")
+
+
+def _join_kb(game_id: int, count: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text=f"🎲 Участвовать ({count})",
+                    callback_data=f"dice:join:{game_id}",
+                )
+            ]
+        ]
+    )
+
+
+# ─── /dice ───────────────────────────────────────────────────────────────────
+
+
+@router.message(Command("dice"))
+@inject
+async def cmd_dice(
+    message: Message,
+    service: FromDishka[DiceService],
+    config: FromDishka[AppConfig],
+    pluralizer: FromDishka[ScorePluralizer],
+    user_repo: FromDishka[IUserRepository],
+) -> None:
+    from datetime import datetime, timedelta
+
+    args = (message.text or "").split()[1:]
+    if len(args) < 2:
+        await message.answer(
+            "🎲 <b>Игра в кости</b>\n\n"
+            "Использование: <code>/dice &lt;ставка&gt; &lt;время&gt;</code>\n"
+            "Пример: <code>/dice 10 2m</code>\n\n"
+            f"Ставка: от {config.dice.min_bet} до {config.dice.max_bet} {pluralizer.pluralize(config.dice.max_bet)}\n"
+            f"Время сбора: от {format_duration(config.dice.min_wait_seconds)} "
+            f"до {format_duration(config.dice.max_wait_seconds)}",
+            parse_mode="HTML",
+        )
+        return
+
+    # Парсим ставку
+    try:
+        bet = int(args[0])
+        if bet <= 0:
+            raise ValueError
+    except ValueError:
+        await message.answer("❌ Ставка должна быть положительным числом.")
+        return
+
+    if bet < config.dice.min_bet:
+        sw = pluralizer.pluralize(config.dice.min_bet)
+        await message.answer(f"❌ Минимальная ставка: {config.dice.min_bet} {sw}.")
+        return
+
+    if bet > config.dice.max_bet:
+        sw = pluralizer.pluralize(config.dice.max_bet)
+        await message.answer(f"❌ Максимальная ставка: {config.dice.max_bet} {sw}.")
+        return
+
+    # Парсим время ожидания
+    wait_seconds = parse_duration(args[1])
+    if wait_seconds is None or wait_seconds <= 0:
+        await message.answer(
+            "❌ Неверный формат времени. Примеры: <code>30s</code>, <code>1m</code>, <code>2m30s</code>",
+            parse_mode="HTML",
+        )
+        return
+
+    if wait_seconds < config.dice.min_wait_seconds:
+        await message.answer(
+            f"❌ Минимальное время ожидания: {format_duration(config.dice.min_wait_seconds)}."
+        )
+        return
+
+    if wait_seconds > config.dice.max_wait_seconds:
+        await message.answer(
+            f"❌ Максимальное время ожидания: {format_duration(config.dice.max_wait_seconds)}."
+        )
+        return
+
+    # Upsert пользователя
+    await user_repo.upsert(
+        User(
+            id=message.from_user.id,
+            username=message.from_user.username,
+            full_name=message.from_user.full_name,
+        )
+    )
+
+    ends_at = datetime.now(TZ_MSK) + timedelta(seconds=wait_seconds)
+    result = await service.create(
+        chat_id=message.chat.id,
+        created_by=message.from_user.id,
+        bet=bet,
+        ends_at=ends_at,
+    )
+
+    if result.already_active:
+        await message.answer("❌ В этом чате уже идёт игра в кости. Дождитесь её завершения.")
+        return
+
+    if result.not_enough or result.game is None:
+        sw = pluralizer.pluralize(bet)
+        score_word_many = pluralizer.pluralize(0)  # форма для "много"
+        await message.answer(
+            f"❌ Недостаточно {score_word_many}. Нужно: {bet} {sw}."
+        )
+        return
+
+    game = result.game
+    sw_bet = pluralizer.pluralize(bet)
+    wait_str = format_duration(wait_seconds)
+
+    text = (
+        "🎲 <b>Игра в кости!</b>\n\n"
+        f"Ставка: <b>{bet} {sw_bet}</b>\n"
+        f"Сбор участников: <b>{wait_str}</b>\n\n"
+        f"Участники: 1\n"
+        f"Нажми кнопку, чтобы сделать ставку и войти в игру!"
+    )
+    sent = await message.answer(text, parse_mode="HTML", reply_markup=_join_kb(game.id, 1))
+    await service.set_message_id(game.id, sent.message_id)
+
+
+# ─── Callback: кнопка «Участвовать» ─────────────────────────────────────────
+
+
+@router.callback_query(F.data.startswith("dice:join:"))
+@inject
+async def cb_dice_join(
+    cb: CallbackQuery,
+    service: FromDishka[DiceService],
+    pluralizer: FromDishka[ScorePluralizer],
+    user_repo: FromDishka[IUserRepository],
+    config: FromDishka[AppConfig],
+) -> None:
+    game_id = int(cb.data.split(":")[2])
+    user_id = cb.from_user.id
+
+    # Upsert пользователя — иначе FK на scores упадёт при списании баллов
+    await user_repo.upsert(
+        User(
+            id=user_id,
+            username=cb.from_user.username,
+            full_name=cb.from_user.full_name,
+        )
+    )
+
+    join_result = await service.join(game_id, user_id)
+
+    if join_result.game_not_found:
+        await cb.answer("Игра уже завершена или не найдена.", show_alert=False)
+        return
+
+    if join_result.already_joined:
+        await cb.answer("Ты уже участвуешь в этой игре.", show_alert=False)
+        return
+
+    if join_result.not_enough:
+        # Получаем ставку из активной игры
+        pending = await service.get_pending_in_chat(cb.message.chat.id)
+        bet = pending.bet if pending else config.dice.min_bet
+        sw = pluralizer.pluralize(bet)
+        score_word_many = pluralizer.pluralize(0)
+        await cb.answer(
+            f"Недостаточно {score_word_many}. Нужно: {bet} {sw}, "
+            f"у вас: {join_result.balance} {pluralizer.pluralize(join_result.balance)}.",
+            show_alert=True,
+        )
+        return
+
+    count = await service.count_participants(game_id)
+    await cb.answer("✅ Ты в игре! Удачи 🎲", show_alert=False)
+
+    try:
+        await cb.message.edit_reply_markup(reply_markup=_join_kb(game_id, count))
+    except Exception:
+        pass

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -54,6 +54,12 @@ blackjack:
   max_games_per_window: 5      # максимум игр в окне
   window_hours: 1              # размер временного окна в часах
 
+dice:
+  min_bet: 1
+  max_bet: 1000
+  min_wait_seconds: 10         # минимальное время сбора участников
+  max_wait_seconds: 3600       # максимальное время сбора (1 час)
+
 llm:
   model: "gemini-2.5-flash-lite"
   base_url: "https://api.aitunnel.ru/v1"

--- a/migrations/V007__dice_game.sql
+++ b/migrations/V007__dice_game.sql
@@ -1,0 +1,22 @@
+-- Игра в кости между участниками чата
+CREATE TABLE dice_games (
+    id          SERIAL PRIMARY KEY,
+    chat_id     BIGINT      NOT NULL,
+    message_id  BIGINT,                         -- id сообщения-анонса (заполняется после отправки)
+    bet         INT         NOT NULL,           -- ставка каждого участника
+    status      TEXT        NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'finished')),
+    ends_at     TIMESTAMPTZ NOT NULL,           -- когда заканчивается сбор участников
+    created_by  BIGINT      NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dice_games_chat_status ON dice_games (chat_id, status);
+CREATE INDEX idx_dice_games_expired     ON dice_games (ends_at) WHERE status = 'pending';
+
+-- Участники (ставка списывается при вступлении)
+CREATE TABLE dice_participants (
+    game_id     INT         NOT NULL REFERENCES dice_games(id) ON DELETE CASCADE,
+    user_id     BIGINT      NOT NULL,
+    joined_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (game_id, user_id)
+);


### PR DESCRIPTION
Players join a timed lobby, then the bot rolls dice for each participant. Prize pool is split equally among players with the highest roll.

- migrations/V007__dice_game.sql: dice_games + dice_participants tables
- bot/domain/dice_entities.py: DiceGame, DiceGameStatus
- bot/application/interfaces/dice_repository.py: IDiceRepository
- bot/application/dice_service.py: create/join/finish game logic with score ops
- bot/infrastructure/db/postgres_dice_repository.py: PostgreSQL implementation
- bot/infrastructure/dice_loop.py: background loop (every 5s) that resolves expired games
- bot/presentation/handlers/dice.py: /dice command + join callback
- Wired into di.py, config_loader.py, config.yaml, main.py