### PR TITLE
fix: /stats crash on _icon attribute, add /slots hourly cooldown

### DIFF
--- a/bot/infrastructure/config_loader.py
+++ b/bot/infrastructure/config_loader.py
@@ -45,6 +45,7 @@ class LimitsConfig(_BaseConfig):
 class SlotsConfig(_BaseConfig):
     min_bet: int = 1
     max_bet: int = 200
+    cooldown_minutes: int = 60  # кулдаун между спинами одного пользователя
 
 
 class HistoryConfig(_BaseConfig):

--- a/bot/presentation/handlers/commands.py
+++ b/bot/presentation/handlers/commands.py
@@ -145,7 +145,6 @@ async def cmd_stats(
 
     stats = await score_service.get_stats(user_id, chat_id)
     p = formatter._p
-    icon = formatter._p._icon
 
     total_games = stats.wins_blackjack + stats.wins_slots + stats.wins_dice + stats.wins_giveaway
 

--- a/bot/presentation/handlers/slots.py
+++ b/bot/presentation/handlers/slots.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 
 from aiogram import Bot, Router
 from aiogram.enums import ParseMode
@@ -15,6 +16,7 @@ from bot.application.interfaces.user_stats_repository import IUserStatsRepositor
 from bot.application.score_service import ScoreService
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter
+from bot.infrastructure.redis_store import RedisStore
 from bot.presentation.utils import NO_PREVIEW, schedule_delete
 
 logger = logging.getLogger(__name__)
@@ -64,6 +66,7 @@ async def cmd_slots(
     command: CommandObject,
     score_service: FromDishka[ScoreService],
     stats_repo: FromDishka[IUserStatsRepository],
+    store: FromDishka[RedisStore],
     config: FromDishka[AppConfig],
     formatter: FromDishka[MessageFormatter],
 ) -> None:
@@ -76,10 +79,16 @@ async def cmd_slots(
     sc = config.slots
 
     if not command.args:
+        cooldown_str = (
+            f"\n\n⏳ Кулдаун: {sc.cooldown_minutes} мин. между спинами"
+            if sc.cooldown_minutes > 0
+            else ""
+        )
         await message.reply(
             f"🎰 <b>Слоты</b>\n\n"
             f"Использование: /slots &lt;ставка&gt;\n"
-            f"Ставка: от {sc.min_bet} до {sc.max_bet} {p.pluralize(sc.max_bet)}\n\n"
+            f"Ставка: от {sc.min_bet} до {sc.max_bet} {p.pluralize(sc.max_bet)}"
+            f"{cooldown_str}\n\n"
             f"<b>Выплаты:</b>\n"
             f"  🎰 Джекпот (777) — ×{_MULT_JACKPOT}\n"
             f"  🏆 Три одинаковых — ×{_MULT_WIN}\n"
@@ -100,10 +109,32 @@ async def cmd_slots(
         await message.reply(f"Ставка: от {sc.min_bet} до {sc.max_bet} {p.pluralize(sc.max_bet)}.")
         return
 
+    # Проверяем кулдаун перед списанием ставки
+    cooldown_seconds = sc.cooldown_minutes * 60
+    if cooldown_seconds > 0:
+        can_play = await store.slots_cooldown_check(user_id, chat_id, cooldown_seconds)
+        if not can_play:
+            # Вычисляем, сколько минут осталось
+            import time
+            key_raw = await store._r.get(f"slots:last:{user_id}:{chat_id}")
+            if key_raw is not None:
+                elapsed = time.time() - float(key_raw)
+                remaining = math.ceil((cooldown_seconds - elapsed) / 60)
+            else:
+                remaining = sc.cooldown_minutes
+            await message.reply(
+                formatter._t["slots_cooldown"].format(minutes=remaining),
+            )
+            return
+
     score = await score_service.get_score(user_id, chat_id)
     if score.value < bet:
         await message.reply(f"Недостаточно баллов. У тебя: {score.value} {p.pluralize(score.value)}.")
         return
+
+    # Устанавливаем кулдаун сразу после всех проверок
+    if cooldown_seconds > 0:
+        await store.slots_cooldown_set(user_id, chat_id, cooldown_seconds)
 
     # Списываем ставку
     await score_service.add_score(user_id, chat_id, -bet, admin_id=user_id)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -58,6 +58,7 @@ blackjack:
 slots:
   min_bet: 1
   max_bet: 200
+  cooldown_minutes: 60      # кулдаун между спинами одного пользователя (в минутах)
 
 dice:
   min_bet: 1

--- a/configs/messages.yaml
+++ b/configs/messages.yaml
@@ -75,3 +75,4 @@ protect_confirm: "🛡 Купить защиту от мута на {hours} ч. 
 protect_not_enough: "Недостаточно баллов. Нужно: {cost} {score_word}, у вас: {balance} {score_word_balance}."
 protect_success: "🛡 {user} купил защиту от мута на {hours} ч. за {cost} {score_word}. Баланс: {balance} {score_word_balance}."
 protect_extended: "🛡 Защита продлена до {until}. Списано: {cost} {score_word}. Баланс: {balance} {score_word_balance}."
+slots_cooldown: "⏳ Следующий спин доступен через {minutes} мин."


### PR DESCRIPTION
fix(commands): remove `formatter._p._icon` in /stats — ScorePluralizer
  exposes `.icon`, not `._icon`; the attribute lookup raised AttributeError
  on every /stats call. The variable was also unused, so it is simply removed.

feat(slots): add per-user cooldown (default 60 min, configurable via
  slots.cooldown_minutes in config.yaml). Uses the existing
  RedisStore.slots_cooldown_check/set helpers. Cooldown is set after all
  validation passes but before the bet is deducted, so a declined play
  never triggers a cooldown. Remaining minutes are shown to the user via
  the new `slots_cooldown` message template.