### PR TITLE
fix: /help crash — daily_reactions_given renamed to daily_negative_given

### DIFF
--- a/bot/presentation/handlers/help_renderer.py
+++ b/bot/presentation/handlers/help_renderer.py
@@ -65,7 +65,7 @@ class HelpRenderer:
 
         # Плейсхолдеры для секций с динамическими значениями
         ctx = dict(
-            daily_reactions_given=lc.daily_reactions_given,
+            daily_reactions_given=lc.daily_negative_given,
             daily_score_received=lc.daily_score_received,
             max_message_age_hours=lc.max_message_age_hours,
             retention_days=config.history.retention_days,


### PR DESCRIPTION
help_renderer.py referenced lc.daily_reactions_given which no longer exists after the LimitsConfig rename in the pydantic refactor.