### PR TITLE
feat: auto-delete bot replies and user commands after 60s

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -25,6 +25,7 @@ from bot.presentation.handlers.reactions import router as reactions_router
 from bot.presentation.handlers.slots import router as slots_router
 from bot.presentation.handlers.tag import router as tag_router
 from bot.presentation.handlers.transfer import router as transfer_router
+from bot.presentation.middlewares.auto_delete import AutoDeleteCommandMiddleware
 from bot.presentation.middlewares.chat_context import ChatContextMiddleware
 from bot.presentation.middlewares.track_message import TrackMessageMiddleware
 
@@ -131,6 +132,7 @@ async def main() -> None:
     dp.message.outer_middleware(ChatContextMiddleware())
     dp.message_reaction.outer_middleware(ChatContextMiddleware())
     dp.callback_query.outer_middleware(ChatContextMiddleware())
+    dp.message.middleware(AutoDeleteCommandMiddleware())
 
     dp.include_router(commands_router)
     dp.include_router(blackjack_router)

--- a/bot/presentation/handlers/admin_score.py
+++ b/bot/presentation/handlers/admin_score.py
@@ -20,7 +20,7 @@ from bot.presentation.handlers._admin_utils import (
     _resolve_user_and_number,
     _resolve_username,
 )
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="admin_score")
@@ -39,17 +39,17 @@ async def cmd_reset(
     if message.from_user is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     if not command.args:
-        await message.reply(formatter._t["admin_usage_reset"])
+        await reply_and_delete(message,formatter._t["admin_usage_reset"])
         return
     target = await _resolve_username(command.args, user_repo)
     if target is None:
-        await message.reply(formatter._t["error_user_not_found"])
+        await reply_and_delete(message,formatter._t["error_user_not_found"])
         return
     new_value = await score_service.set_score(target.id, message.chat.id, 0, admin_id=message.from_user.id)
-    await message.reply(
+    await reply_and_delete(message,
         _admin_reply(formatter, target, new_value), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW
     )
 
@@ -67,18 +67,18 @@ async def cmd_set(
     if message.from_user is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     parsed = await _resolve_user_and_number(command.args, user_repo)
     if parsed is None or parsed[0] is None:
-        await message.reply(formatter._t["admin_usage_set"])
+        await reply_and_delete(message,formatter._t["admin_usage_set"])
         return
     target, amount = parsed
     if target is None:
-        await message.reply(formatter._t["error_user_not_found"])
+        await reply_and_delete(message,formatter._t["error_user_not_found"])
         return
     new_value = await score_service.set_score(target.id, message.chat.id, amount, admin_id=message.from_user.id)
-    await message.reply(
+    await reply_and_delete(message,
         _admin_reply(formatter, target, new_value), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW
     )
 
@@ -96,21 +96,21 @@ async def cmd_add(
     if message.from_user is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     parsed = await _resolve_user_and_number(command.args, user_repo)
     if parsed is None:
-        await message.reply(formatter._t["admin_usage_add"])
+        await reply_and_delete(message,formatter._t["admin_usage_add"])
         return
     target, amount = parsed
     if target is None:
-        await message.reply(formatter._t["error_user_not_found"])
+        await reply_and_delete(message,formatter._t["error_user_not_found"])
         return
     if amount <= 0:
-        await message.reply(formatter._t["admin_negative_amount"])
+        await reply_and_delete(message,formatter._t["admin_negative_amount"])
         return
     new_value = await score_service.add_score(target.id, message.chat.id, amount, admin_id=message.from_user.id)
-    await message.reply(
+    await reply_and_delete(message,
         _admin_reply(formatter, target, new_value), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW
     )
 
@@ -128,20 +128,20 @@ async def cmd_sub(
     if message.from_user is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     parsed = await _resolve_user_and_number(command.args, user_repo)
     if parsed is None:
-        await message.reply(formatter._t["admin_usage_sub"])
+        await reply_and_delete(message,formatter._t["admin_usage_sub"])
         return
     target, amount = parsed
     if target is None:
-        await message.reply(formatter._t["error_user_not_found"])
+        await reply_and_delete(message,formatter._t["error_user_not_found"])
         return
     if amount <= 0:
-        await message.reply(formatter._t["admin_negative_amount"])
+        await reply_and_delete(message,formatter._t["admin_negative_amount"])
         return
     new_value = await score_service.add_score(target.id, message.chat.id, -amount, admin_id=message.from_user.id)
-    await message.reply(
+    await reply_and_delete(message,
         _admin_reply(formatter, target, new_value), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW
     )

--- a/bot/presentation/handlers/admin_user.py
+++ b/bot/presentation/handlers/admin_user.py
@@ -23,7 +23,7 @@ from bot.presentation.handlers._admin_utils import (
     _promote_kwargs,
     _resolve_username,
 )
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="admin_user")
@@ -42,24 +42,24 @@ async def cmd_save(
     if message.from_user is None or message.bot is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     target = await _resolve_username(command.args, user_repo)
     if target is None:
-        await message.reply(formatter._t["save_usage"])
+        await reply_and_delete(message,formatter._t["save_usage"])
         return
     display = user_link(target.username, target.full_name, target.id)
     try:
         member = await message.bot.get_chat_member(message.chat.id, target.id)
     except Exception:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["save_not_admin"].format(user=display),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
         )
         return
     if not isinstance(member, ChatMemberAdministrator):
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["save_not_admin"].format(user=display),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
@@ -69,7 +69,7 @@ async def cmd_save(
     existing = await saved_perms_repo.get(target.id, message.chat.id)
     await saved_perms_repo.save(target.id, message.chat.id, perms)
     key = "save_overwritten" if existing else "save_success"
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t[key].format(user=display), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW
     )
 
@@ -87,16 +87,16 @@ async def cmd_restore(
     if message.from_user is None or message.bot is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     target = await _resolve_username(command.args, user_repo)
     if target is None:
-        await message.reply(formatter._t["restore_usage"])
+        await reply_and_delete(message,formatter._t["restore_usage"])
         return
     display = user_link(target.username, target.full_name, target.id)
     perms = await saved_perms_repo.get(target.id, message.chat.id)
     if perms is None:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["restore_not_found"].format(user=display),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
@@ -110,9 +110,9 @@ async def cmd_restore(
             )
     except Exception:
         logger.exception("Failed to restore permissions for user %d", target.id)
-        await message.reply(formatter._t["restore_failed"])
+        await reply_and_delete(message,formatter._t["restore_failed"])
         return
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["restore_success"].format(user=display),
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,
@@ -132,20 +132,20 @@ async def cmd_op(
     if message.from_user is None or message.bot is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     target = await _resolve_username(command.args, user_repo)
     if target is None:
-        await message.reply(formatter._t["op_usage"])
+        await reply_and_delete(message,formatter._t["op_usage"])
         return
     display = user_link(target.username, target.full_name, target.id)
     try:
         member = await message.bot.get_chat_member(message.chat.id, target.id)
     except Exception:
-        await message.reply(formatter._t["op_failed"])
+        await reply_and_delete(message,formatter._t["op_failed"])
         return
     if isinstance(member, (ChatMemberOwner, ChatMemberAdministrator)):
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["op_already"].format(user=display),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
@@ -157,10 +157,10 @@ async def cmd_op(
         )
     except Exception:
         logger.exception("Failed to op user %d", target.id)
-        await message.reply(formatter._t["op_failed"])
+        await reply_and_delete(message,formatter._t["op_failed"])
         return
     await saved_perms_repo.save(target.id, message.chat.id, MODERATOR_PERMS)
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["op_success"].format(user=display),
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,
@@ -179,27 +179,27 @@ async def cmd_deop(
     if message.from_user is None or message.bot is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     target = await _resolve_username(command.args, user_repo)
     if target is None:
-        await message.reply(formatter._t["op_usage"])
+        await reply_and_delete(message,formatter._t["op_usage"])
         return
     display = user_link(target.username, target.full_name, target.id)
     try:
         member = await message.bot.get_chat_member(message.chat.id, target.id)
     except Exception:
-        await message.reply(formatter._t["op_failed"])
+        await reply_and_delete(message,formatter._t["op_failed"])
         return
     if isinstance(member, ChatMemberOwner):
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["op_already"].format(user=display),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
         )
         return
     if not isinstance(member, ChatMemberAdministrator):
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["deop_not_admin"].format(user=display),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
@@ -210,9 +210,9 @@ async def cmd_deop(
         await message.bot.promote_chat_member(chat_id=message.chat.id, user_id=target.id, **demote_kw)
     except Exception:
         logger.exception("Failed to deop user %d", target.id)
-        await message.reply(formatter._t["op_failed"])
+        await reply_and_delete(message,formatter._t["op_failed"])
         return
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["deop_success"].format(user=display),
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,

--- a/bot/presentation/handlers/commands.py
+++ b/bot/presentation/handlers/commands.py
@@ -19,7 +19,7 @@ from bot.application.score_service import ScoreService
 from bot.domain.tz import to_msk
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter, user_link
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete, schedule_delete
 
 router = Router(name="commands")
 
@@ -55,7 +55,7 @@ async def cmd_score(
     if command.args:
         target_user = await user_repo.get_by_username(command.args.strip().lstrip("@"))
         if target_user is None:
-            await message.reply(formatter._t["error_user_not_found"])
+            await reply_and_delete(message, formatter._t["error_user_not_found"])
             return
         display_name = user_link(target_user.username, target_user.full_name, target_user.id)
     else:
@@ -64,7 +64,7 @@ async def cmd_score(
         display_name = user_link(message.from_user.username, message.from_user.full_name or "", message.from_user.id)
     user_id = target_user.id if target_user else message.from_user.id  # type: ignore[union-attr]
     score = await score_service.get_score(user_id, chat_id)
-    await message.reply(
+    await reply_and_delete(message,
         formatter.score_info(display_name, score.value), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW
     )
 
@@ -106,9 +106,9 @@ async def cmd_top(
         for rank, name, value in rows:
             lines.append(f"{rank}. {name} — {value} {p.pluralize(value)}")
         text = "\n".join(lines) if rows else "🔻 <b>Антирейтинг</b>\n<i>Нет данных</i>"
-        await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
+        await reply_and_delete(message, text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
     else:
-        await message.reply(formatter.leaderboard(rows), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
+        await reply_and_delete(message, formatter.leaderboard(rows), parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
 
 
 @router.message(Command("stats"))
@@ -131,7 +131,7 @@ async def cmd_stats(
     elif command.args:
         target_user = await user_repo.get_by_username(command.args.strip().lstrip("@"))
         if target_user is None:
-            await message.reply(formatter._t.get("error_user_not_found", "Пользователь не найден."))
+            await reply_and_delete(message, formatter._t.get("error_user_not_found", "Пользователь не найден."))
             return
 
     if target_user is not None:
@@ -160,7 +160,7 @@ async def cmd_stats(
         f"  🎟 Розыгрыши: {stats.wins_giveaway}\n"
         f"  <i>Итого: {total_games}</i>"
     )
-    await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
+    await reply_and_delete(message, text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
 
 
 @router.message(Command("history"))
@@ -196,7 +196,7 @@ async def cmd_history(
     _history_pages[(chat_id, uid)] = pages
     text = formatter.history(pages[0], config.history.retention_days)
     kb = _history_kb(0, len(pages), chat_id, uid)
-    await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW, reply_markup=kb)
+    await reply_and_delete(message, text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW, reply_markup=kb)
 
 
 @router.callback_query(F.data.startswith("hist:"))
@@ -283,7 +283,7 @@ async def cmd_limits(
         f"<b>Блекджек:</b>\n"
         f"  Ставка: {bjc.min_bet}–{bjc.max_bet} {p.pluralize(bjc.max_bet)}"
     )
-    await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
+    await reply_and_delete(message, text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
 
 
 # ── Кэш для пагинации истории пользователя ───────────────────────
@@ -328,7 +328,7 @@ async def cmd_uhistory(
         target = await user_repo.get_by_username(username)
 
     if target is None:
-        await message.reply(
+        await reply_and_delete(message,
             "Использование: <code>/uhistory @username</code> или реплай на сообщение.",
             parse_mode=ParseMode.HTML,
         )
@@ -338,7 +338,7 @@ async def cmd_uhistory(
     target_link = user_link(target.username, target.full_name, target.id)
 
     if not events:
-        await message.reply(
+        await reply_and_delete(message,
             f"Нет событий для {target_link} за последние {config.history.retention_days} дн.",
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
@@ -372,7 +372,7 @@ async def cmd_uhistory(
     text = f"{title}\n<blockquote expandable>{body}</blockquote>"
 
     kb = _uhistory_kb(0, len(pages), chat_id, uid, target.id)
-    await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW, reply_markup=kb)
+    await reply_and_delete(message, text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW, reply_markup=kb)
 
 
 @router.callback_query(F.data.startswith("uhist:"))

--- a/bot/presentation/handlers/help.py
+++ b/bot/presentation/handlers/help.py
@@ -13,7 +13,7 @@ from dishka.integrations.aiogram import FromDishka, inject
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter
 from bot.presentation.handlers.help_renderer import HelpRenderer
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="help")
@@ -30,7 +30,8 @@ async def cmd_help(
     if message.from_user is None:
         return
     uid = message.from_user.id
-    await message.reply(
+    await reply_and_delete(
+        message,
         renderer.main_text(config.score.icon),
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,

--- a/bot/presentation/handlers/mute.py
+++ b/bot/presentation/handlers/mute.py
@@ -35,7 +35,7 @@ from bot.presentation.handlers._admin_utils import (
     _resolve_username,
     _unmute_user,
 )
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="mute")
@@ -60,17 +60,17 @@ async def cmd_mute(
     p = formatter._p
     parsed = await _resolve_mute_args(command.args, message, user_repo)
     if parsed is None:
-        await message.reply(formatter._t["mute_usage"].format(min=mute_cfg.min_minutes, max=mute_cfg.max_minutes))
+        await reply_and_delete(message,formatter._t["mute_usage"].format(min=mute_cfg.min_minutes, max=mute_cfg.max_minutes))
         return
     target, minutes = parsed
     if target is None:
-        await message.reply(formatter._t["error_user_not_found"])
+        await reply_and_delete(message,formatter._t["error_user_not_found"])
         return
     if target.id == message.from_user.id:
-        await message.reply(formatter._t["mute_self"])
+        await reply_and_delete(message,formatter._t["mute_self"])
         return
     if minutes < mute_cfg.min_minutes or minutes > mute_cfg.max_minutes:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["mute_invalid_minutes"].format(min=mute_cfg.min_minutes, max=mute_cfg.max_minutes)
         )
         return
@@ -78,7 +78,7 @@ async def cmd_mute(
     if mute_cfg.daily_limit > 0:
         daily_count = await store.mute_daily_count(message.from_user.id, message.chat.id)
         if daily_count >= mute_cfg.daily_limit:
-            await message.reply(
+            await reply_and_delete(message,
                 formatter._t["mute_daily_limit"].format(count=daily_count, limit=mute_cfg.daily_limit)
             )
             return
@@ -86,7 +86,7 @@ async def cmd_mute(
     target_link = user_link(target.username, target.full_name, target.id)
     if mute_cfg.target_cooldown_hours > 0:
         if not await store.mute_target_cooldown_ok(message.from_user.id, target.id, message.chat.id):
-            await message.reply(
+            await reply_and_delete(message,
                 formatter._t["mute_target_cooldown"].format(
                     target=target_link, hours=mute_cfg.target_cooldown_hours
                 ),
@@ -97,7 +97,7 @@ async def cmd_mute(
     protected_until = await protection_repo.get(target.id, message.chat.id)
     if protected_until is not None:
         until_str = protected_until.astimezone(TZ_MSK).strftime("%H:%M %d.%m")
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["mute_target_protected"].format(target=target_link, until=until_str),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
@@ -106,7 +106,7 @@ async def cmd_mute(
     cost = minutes * mute_cfg.cost_per_minute
     score = await score_service.get_score(message.from_user.id, message.chat.id)
     if score.value < cost:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["mute_not_enough"].format(
                 cost=cost,
                 score_word=p.pluralize(cost),
@@ -121,7 +121,7 @@ async def cmd_mute(
     try:
         member = await bot.get_chat_member(chat_id, target.id)
     except Exception:
-        await message.reply(formatter._t["mute_failed"])
+        await reply_and_delete(message,formatter._t["mute_failed"])
         return
     was_admin = isinstance(member, ChatMemberAdministrator)
     admin_perms: dict | None = None
@@ -132,7 +132,7 @@ async def cmd_mute(
                 chat_id=chat_id, user_id=target.id, **{f: False for f in _ADMIN_PERM_FIELDS}
             )
         except Exception:
-            await message.reply(formatter._t["mute_failed"])
+            await reply_and_delete(message,formatter._t["mute_failed"])
             return
     try:
         await bot.restrict_chat_member(
@@ -147,7 +147,7 @@ async def cmd_mute(
                 await bot.promote_chat_member(chat_id=chat_id, user_id=target.id, **_promote_kwargs(admin_perms))
             except Exception:
                 logger.exception("Failed to restore admin rights after mute failure")
-        await message.reply(formatter._t["mute_failed"])
+        await reply_and_delete(message,formatter._t["mute_failed"])
         return
     await mute_service.save_mute(
         MuteEntry(
@@ -175,7 +175,7 @@ async def cmd_mute(
                 admin_permissions=admin_perms,
             ),
         )
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["mute_not_enough"].format(
                 cost=cost,
                 score_word=p.pluralize(cost),
@@ -190,7 +190,7 @@ async def cmd_mute(
     if mute_cfg.target_cooldown_hours > 0:
         await store.mute_target_cooldown_set(message.from_user.id, target.id, chat_id, mute_cfg.target_cooldown_hours)
     actor_link = user_link(message.from_user.username, message.from_user.full_name or "", message.from_user.id)
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["mute_success"].format(
             actor=actor_link,
             target=target_link,
@@ -231,24 +231,24 @@ async def cmd_amute(
         except Exception:
             has_restrict = False
         if not has_restrict:
-            await message.reply(formatter._t["amute_not_allowed"])
+            await reply_and_delete(message,formatter._t["amute_not_allowed"])
             return
     parsed = await _resolve_mute_args(command.args, message, user_repo)
     if parsed is None:
-        await message.reply(formatter._t["amute_usage"].format(min=mute_cfg.min_minutes, max=mute_cfg.max_minutes))
+        await reply_and_delete(message,formatter._t["amute_usage"].format(min=mute_cfg.min_minutes, max=mute_cfg.max_minutes))
         return
     target, minutes = parsed
     if target is None:
-        await message.reply(formatter._t["error_user_not_found"])
+        await reply_and_delete(message,formatter._t["error_user_not_found"])
         return
     if target.id == message.from_user.id:
-        await message.reply(formatter._t["mute_self"])
+        await reply_and_delete(message,formatter._t["mute_self"])
         return
     until = datetime.now(TZ_MSK) + timedelta(minutes=minutes)
     try:
         member = await bot.get_chat_member(chat_id, target.id)
     except Exception:
-        await message.reply(formatter._t["mute_failed"])
+        await reply_and_delete(message,formatter._t["mute_failed"])
         return
     was_admin = isinstance(member, ChatMemberAdministrator)
     admin_perms: dict | None = None
@@ -259,7 +259,7 @@ async def cmd_amute(
                 chat_id=chat_id, user_id=target.id, **{f: False for f in _ADMIN_PERM_FIELDS}
             )
         except Exception:
-            await message.reply(formatter._t["mute_failed"])
+            await reply_and_delete(message,formatter._t["mute_failed"])
             return
     try:
         await bot.restrict_chat_member(
@@ -274,7 +274,7 @@ async def cmd_amute(
                 await bot.promote_chat_member(chat_id=chat_id, user_id=target.id, **_promote_kwargs(admin_perms))
             except Exception:
                 logger.exception("Failed to restore admin rights after amute failure")
-        await message.reply(formatter._t["mute_failed"])
+        await reply_and_delete(message,formatter._t["mute_failed"])
         return
     await mute_service.save_mute(
         MuteEntry(
@@ -288,7 +288,7 @@ async def cmd_amute(
     )
     actor_link = user_link(message.from_user.username, message.from_user.full_name or "", message.from_user.id)
     target_link = user_link(target.username, target.full_name, target.id)
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["amute_success"].format(actor=actor_link, target=target_link, minutes=minutes),
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,
@@ -310,7 +310,7 @@ async def cmd_selfmute(
     min_sec = mute_cfg.selfmute_min_minutes * 60
     max_sec = mute_cfg.selfmute_max_minutes * 60
     if not command.args:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["selfmute_usage"].format(
                 min=mute_cfg.selfmute_min_minutes, max=mute_cfg.selfmute_max_minutes
             )
@@ -318,7 +318,7 @@ async def cmd_selfmute(
         return
     seconds = parse_duration(command.args)
     if seconds is None or seconds <= 0 or seconds < min_sec or seconds > max_sec:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["selfmute_invalid_minutes"].format(
                 min=mute_cfg.selfmute_min_minutes, max=mute_cfg.selfmute_max_minutes
             )
@@ -333,7 +333,7 @@ async def cmd_selfmute(
     try:
         member = await bot.get_chat_member(chat_id, user_id)
         if isinstance(member, ChatMemberOwner):
-            await message.reply(formatter._t["selfmute_failed"])
+            await reply_and_delete(message,formatter._t["selfmute_failed"])
             return
         if isinstance(member, ChatMemberAdministrator):
             was_admin = True
@@ -343,7 +343,7 @@ async def cmd_selfmute(
             )
     except TelegramBadRequest as e:
         logger.warning("selfmute pre-check failed for user %d: %s", user_id, e)
-        await message.reply(formatter._t["selfmute_failed"])
+        await reply_and_delete(message,formatter._t["selfmute_failed"])
         return
     try:
         await bot.restrict_chat_member(
@@ -355,7 +355,7 @@ async def cmd_selfmute(
                 await bot.promote_chat_member(chat_id=chat_id, user_id=user_id, **_promote_kwargs(admin_perms))
             except Exception:
                 logger.exception("Failed to restore admin rights after selfmute failure for user %d", user_id)
-        await message.reply(formatter._t["selfmute_failed"])
+        await reply_and_delete(message,formatter._t["selfmute_failed"])
         return
     await mute_service.save_mute(
         MuteEntry(
@@ -368,7 +368,7 @@ async def cmd_selfmute(
         )
     )
     user_link_str = user_link(message.from_user.username, message.from_user.full_name or "", user_id)
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["selfmute_success"].format(user=user_link_str, duration=format_duration(seconds)),
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,
@@ -388,7 +388,7 @@ async def cmd_unmute(
     if message.from_user is None or message.bot is None:
         return
     if not is_admin(message.from_user.username, config.admin.users):
-        await message.reply(formatter._t["admin_not_allowed"])
+        await reply_and_delete(message,formatter._t["admin_not_allowed"])
         return
     target = await _resolve_username(command.args, user_repo)
     if target is None:
@@ -399,19 +399,19 @@ async def cmd_unmute(
             tg = reply.from_user
             target = DomainUser(id=tg.id, username=tg.username, full_name=tg.full_name or str(tg.id))
         else:
-            await message.reply(formatter._t["unmute_usage"])
+            await reply_and_delete(message,formatter._t["unmute_usage"])
             return
     display = user_link(target.username, target.full_name, target.id)
     entry = await mute_service._repo.get(target.id, message.chat.id)
     if entry is None:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["unmute_not_muted"].format(user=display),
             parse_mode=ParseMode.HTML,
             link_preview_options=NO_PREVIEW,
         )
         return
     await _unmute_user(message.bot, mute_service, entry)
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["unmute_success"].format(user=display),
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,

--- a/bot/presentation/handlers/protect.py
+++ b/bot/presentation/handlers/protect.py
@@ -21,7 +21,7 @@ from bot.application.score_service import SPECIAL_EMOJI, ScoreService
 from bot.domain.tz import TZ_MSK
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter, user_link
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="protect")
@@ -46,7 +46,7 @@ async def cmd_protect(
     hours = mute_cfg.protection_duration_hours
     score = await score_service.get_score(user_id, chat_id)
     if score.value < cost:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["protect_not_enough"].format(
                 cost=cost,
                 score_word=p.pluralize(cost),
@@ -66,7 +66,7 @@ async def cmd_protect(
             ]
         ]
     )
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["protect_confirm"].format(
             hours=hours,
             cost=cost,
@@ -176,8 +176,8 @@ async def cmd_unprotect(
 
     existing = await protection_repo.get(user_id, chat_id)
     if existing is None:
-        await message.reply("У тебя нет активной защиты.")
+        await reply_and_delete(message,"У тебя нет активной защиты.")
         return
 
     await protection_repo.delete(user_id, chat_id)
-    await message.reply("🔓 Защита снята.")
+    await reply_and_delete(message,"🔓 Защита снята.")

--- a/bot/presentation/handlers/tag.py
+++ b/bot/presentation/handlers/tag.py
@@ -15,7 +15,7 @@ from bot.application.score_service import SPECIAL_EMOJI, ScoreService
 from bot.domain.bot_utils import is_admin
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter, user_link
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="tag")
@@ -39,7 +39,7 @@ async def cmd_tag(
     chat_id = message.chat.id
     args = command.args
     if not args:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["tag_usage"].format(cost_self=tc.cost_self, sw_self=p.pluralize(tc.cost_self))
         )
         return
@@ -47,11 +47,11 @@ async def cmd_tag(
     if parts[0].startswith("@"):
         target = await user_repo.get_by_username(parts[0].lstrip("@"))
         if target is None:
-            await message.reply(formatter._t["error_user_not_found"])
+            await reply_and_delete(message,formatter._t["error_user_not_found"])
             return
         new_tag = parts[1].strip() if len(parts) > 1 else None
         if new_tag is None:
-            await message.reply(
+            await reply_and_delete(message,
                 formatter._t["tag_usage"].format(cost_self=tc.cost_self, sw_self=p.pluralize(tc.cost_self))
             )
             return
@@ -59,14 +59,14 @@ async def cmd_tag(
     else:
         target = await user_repo.get_by_id(message.from_user.id)
         if target is None:
-            await message.reply(formatter._t["error_user_not_found"])
+            await reply_and_delete(message,formatter._t["error_user_not_found"])
             return
         new_tag = args.strip()
         is_self = True
     clearing = new_tag == "--clear"
     is_free = is_admin(message.from_user.username, config.admin.users)
     if not clearing and len(new_tag) > tc.max_length:
-        await message.reply(formatter._t["tag_too_long"].format(max=tc.max_length))
+        await reply_and_delete(message,formatter._t["tag_too_long"].format(max=tc.max_length))
         return
     if is_self:
         cost = tc.cost_self
@@ -74,7 +74,7 @@ async def cmd_tag(
         try:
             member = await bot.get_chat_member(chat_id, target.id)
         except Exception:
-            await message.reply(formatter._t["tag_failed"])
+            await reply_and_delete(message,formatter._t["tag_failed"])
             return
         if isinstance(member, ChatMemberOwner):
             cost = tc.cost_owner
@@ -85,7 +85,7 @@ async def cmd_tag(
     if not is_free:
         score = await score_service.get_score(message.from_user.id, chat_id)
         if score.value < cost:
-            await message.reply(
+            await reply_and_delete(message,
                 formatter._t["tag_not_enough"].format(
                     cost=cost,
                     score_word=p.pluralize(cost),
@@ -97,7 +97,7 @@ async def cmd_tag(
     try:
         await bot.set_chat_member_tag(chat_id=chat_id, user_id=target.id, tag=None if clearing else new_tag)
     except Exception:
-        await message.reply(formatter._t["tag_failed"])
+        await reply_and_delete(message,formatter._t["tag_failed"])
         return
     target_link = user_link(target.username, target.full_name, target.id)
     if is_free:
@@ -106,13 +106,13 @@ async def cmd_tag(
             if clearing
             else formatter._t["tag_success_free"].format(target=target_link, tag=new_tag)
         )
-        await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
+        await reply_and_delete(message,text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
         return
     result = await score_service.spend_score(
         actor_id=message.from_user.id, target_id=target.id, chat_id=chat_id, cost=cost, emoji=SPECIAL_EMOJI["tag"]
     )
     if not result.success:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["tag_not_enough"].format(
                 cost=cost,
                 score_word=p.pluralize(cost),
@@ -138,4 +138,4 @@ async def cmd_tag(
             balance=result.new_balance,
             score_word_balance=p.pluralize(result.new_balance),
         )
-    await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
+    await reply_and_delete(message,text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)

--- a/bot/presentation/handlers/transfer.py
+++ b/bot/presentation/handlers/transfer.py
@@ -15,7 +15,7 @@ from bot.application.score_service import ScoreService
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter, user_link
 from bot.presentation.handlers._admin_utils import _resolve_user_and_number
-from bot.presentation.utils import NO_PREVIEW
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="transfer")
@@ -37,23 +37,23 @@ async def cmd_transfer(
     chat_id = message.chat.id
     parsed = await _resolve_user_and_number(command.args, user_repo)
     if parsed is None:
-        await message.reply(formatter._t["transfer_usage"])
+        await reply_and_delete(message,formatter._t["transfer_usage"])
         return
     target, amount = parsed
     if amount <= 0:
-        await message.reply(formatter._t["transfer_invalid_amount"])
+        await reply_and_delete(message,formatter._t["transfer_invalid_amount"])
         return
     if target is None:
-        await message.reply(formatter._t["error_user_not_found"])
+        await reply_and_delete(message,formatter._t["error_user_not_found"])
         return
     if target.id == message.from_user.id:
-        await message.reply(formatter._t["transfer_self"])
+        await reply_and_delete(message,formatter._t["transfer_self"])
         return
     result = await score_service.transfer_score(
         sender_id=message.from_user.id, receiver_id=target.id, chat_id=chat_id, amount=amount
     )
     if not result.success:
-        await message.reply(
+        await reply_and_delete(message,
             formatter._t["transfer_not_enough"].format(
                 amount=amount,
                 score_word=p.pluralize(amount),
@@ -64,7 +64,7 @@ async def cmd_transfer(
         return
     sender_link = user_link(message.from_user.username, message.from_user.full_name or "", message.from_user.id)
     receiver_link = user_link(target.username, target.full_name, target.id)
-    await message.reply(
+    await reply_and_delete(message,
         formatter._t["transfer_success"].format(
             sender=sender_link,
             receiver=receiver_link,

--- a/bot/presentation/middlewares/auto_delete.py
+++ b/bot/presentation/middlewares/auto_delete.py
@@ -1,0 +1,33 @@
+"""Middleware: автоудаление команд пользователя через заданное время."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from aiogram import Bot
+from aiogram.types import Message
+
+from bot.presentation.utils import schedule_delete
+
+_COMMAND_DELETE_DELAY = 60  # секунд
+
+
+class AutoDeleteCommandMiddleware:
+    """Удаляет входящее сообщение-команду (/cmd ...) через _COMMAND_DELETE_DELAY секунд.
+
+    Не затрагивает ответы бота — каждый хендлер управляет ими самостоятельно.
+    """
+
+    async def __call__(
+        self,
+        handler: Callable[[Message, dict[str, Any]], Awaitable[Any]],
+        event: Message,
+        data: dict[str, Any],
+    ) -> Any:
+        result = await handler(event, data)
+        # Планируем удаление только после успешной обработки
+        if event.text and event.text.startswith("/"):
+            bot: Bot | None = event.bot or data.get("bot")
+            if bot:
+                schedule_delete(bot, event, delay=_COMMAND_DELETE_DELAY)
+        return result

--- a/bot/presentation/utils.py
+++ b/bot/presentation/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from aiogram import Bot
 from aiogram.types import LinkPreviewOptions, Message
@@ -12,6 +13,9 @@ logger = logging.getLogger(__name__)
 
 # Единственное определение NO_PREVIEW для всего проекта
 NO_PREVIEW = LinkPreviewOptions(is_disabled=True)
+
+# Задержка автоудаления для обычных (не игровых) ответов бота
+AUTO_DELETE_DELAY = 60
 
 
 async def _delete_after(bot: Bot, chat_id: int, message_id: int, delay: int) -> None:
@@ -26,3 +30,11 @@ def schedule_delete(bot: Bot, *messages: Message, delay: int = 120) -> None:
     """Планирует удаление одного или нескольких сообщений через delay секунд."""
     for msg in messages:
         asyncio.create_task(_delete_after(bot, msg.chat.id, msg.message_id, delay))
+
+
+async def reply_and_delete(message: Message, *args: Any, delay: int = AUTO_DELETE_DELAY, **kwargs: Any) -> Message:
+    """Отправляет reply и планирует его удаление через delay секунд."""
+    reply = await message.reply(*args, **kwargs)
+    if message.bot:
+        schedule_delete(message.bot, reply, delay=delay)
+    return reply


### PR DESCRIPTION
- Add reply_and_delete() helper in utils.py (wraps reply + schedule delete at 60s)
- Add AutoDeleteCommandMiddleware to delete incoming /commands after 60s
- Register middleware in main.py
- Replace all message.reply() calls with reply_and_delete() in non-game handlers (commands, mute, tag, transfer, protect, admin_score, admin_user, help)
- Game handlers (blackjack, slots, dice, giveaway) retain their own schedule_delete