### PR TITLE
feat: add /renew command — reset game limits for 100 kirchiks

### DIFF
--- a/bot/infrastructure/config_loader.py
+++ b/bot/infrastructure/config_loader.py
@@ -149,6 +149,11 @@ class LlmConfig(_BaseConfig):
     )
 
 
+class RenewConfig(_BaseConfig):
+    cost: int = 100           # стоимость одного обновления лимитов
+    daily_limit: int = 2      # сколько раз в сутки можно использовать /renew
+
+
 class AppConfig(_BaseConfig):
     score: ScoreConfig = ScoreConfig()
     reactions: dict[str, int] = {}
@@ -164,6 +169,7 @@ class AppConfig(_BaseConfig):
     dice: DiceConfig = DiceConfig()
     llm: LlmConfig = LlmConfig()
     system: SystemConfig = SystemConfig()
+    renew: RenewConfig = RenewConfig()
 
 
 def load_config(path: str | Path | None = None) -> AppConfig:

--- a/bot/infrastructure/redis_store.py
+++ b/bot/infrastructure/redis_store.py
@@ -175,6 +175,32 @@ class RedisStore:
         key = f"{self._MUTE_TARGET}{actor_id}:{target_id}:{chat_id}"
         await self._r.set(key, "1", ex=hours * 3600)
 
+    # ── /renew: сброс игровых лимитов ────────────────────────────
+
+    _RENEW_DAILY = "renew:daily:"  # renew:daily:{user_id}:{chat_id}
+
+    async def renew_daily_count(self, user_id: int, chat_id: int) -> int:
+        """Сколько раз сегодня пользователь уже использовал /renew."""
+        key = f"{self._RENEW_DAILY}{user_id}:{chat_id}"
+        raw = await self._r.get(key)
+        return int(raw or 0)
+
+    async def renew_daily_increment(self, user_id: int, chat_id: int) -> None:
+        """Записать использование /renew. TTL — 24 часа."""
+        key = f"{self._RENEW_DAILY}{user_id}:{chat_id}"
+        pipe = self._r.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, 86400)
+        await pipe.execute()
+
+    async def renew_game_limits(self, user_id: int, chat_id: int) -> None:
+        """Сбросить все игровые лимиты пользователя (слоты и блекджек)."""
+        await self._r.delete(
+            f"{_SLOTS_LAST}{user_id}:{chat_id}",
+            f"{_SLOTS_DAILY}{user_id}:{chat_id}",
+            f"{_BJ_HISTORY}{user_id}:{chat_id}",
+        )
+
     # ── Slots: прогрессивный джекпот ─────────────────────────────
 
     async def jackpot_add(self, chat_id: int, amount: int) -> None:

--- a/bot/main.py
+++ b/bot/main.py
@@ -24,6 +24,7 @@ from bot.presentation.handlers.protect import router as protect_router
 from bot.presentation.handlers.reactions import router as reactions_router
 from bot.presentation.handlers.slots import router as slots_router
 from bot.presentation.handlers.tag import router as tag_router
+from bot.presentation.handlers.renew import router as renew_router
 from bot.presentation.handlers.transfer import router as transfer_router
 from bot.presentation.middlewares.auto_delete import AutoDeleteCommandMiddleware
 from bot.presentation.middlewares.chat_context import ChatContextMiddleware
@@ -144,6 +145,7 @@ async def main() -> None:
     dp.include_router(mute_router)
     dp.include_router(tag_router)
     dp.include_router(transfer_router)
+    dp.include_router(renew_router)
     dp.include_router(protect_router)
     dp.include_router(admin_score_router)
     dp.include_router(admin_user_router)

--- a/bot/presentation/handlers/renew.py
+++ b/bot/presentation/handlers/renew.py
@@ -1,0 +1,91 @@
+"""Обработчик команды /renew — сброс игровых лимитов за кирчики."""
+
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.enums import ParseMode
+from aiogram.filters import Command
+from aiogram.types import Message
+from dishka.integrations.aiogram import FromDishka, inject
+
+from bot.application.score_service import ScoreService
+from bot.infrastructure.config_loader import AppConfig
+from bot.infrastructure.message_formatter import MessageFormatter
+from bot.infrastructure.redis_store import RedisStore
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete
+
+router = Router(name="renew")
+
+
+@router.message(Command("renew"))
+@inject
+async def cmd_renew(
+    message: Message,
+    score_service: FromDishka[ScoreService],
+    store: FromDishka[RedisStore],
+    formatter: FromDishka[MessageFormatter],
+    config: FromDishka[AppConfig],
+) -> None:
+    """Сброс лимитов слотов и блекджека за {cost} кирчиков. До {daily_limit} раз в сутки."""
+    if message.from_user is None:
+        return
+
+    rc = config.renew
+    p = formatter._p
+    user_id = message.from_user.id
+    chat_id = message.chat.id
+
+    # Проверка дневного лимита
+    count = await store.renew_daily_count(user_id, chat_id)
+    if count >= rc.daily_limit:
+        await reply_and_delete(
+            message,
+            formatter._t["renew_daily_limit"].format(count=count, limit=rc.daily_limit),
+        )
+        return
+
+    # Проверка баланса
+    score = await score_service.get_score(user_id, chat_id)
+    if score.value < rc.cost:
+        await reply_and_delete(
+            message,
+            formatter._t["renew_not_enough"].format(
+                cost=rc.cost,
+                score_word=p.pluralize(rc.cost),
+                balance=score.value,
+                score_word_balance=p.pluralize(score.value),
+            ),
+        )
+        return
+
+    # Списываем баллы
+    result = await score_service.spend_score(
+        actor_id=user_id, target_id=user_id, chat_id=chat_id, cost=rc.cost
+    )
+    if not result.success:
+        await reply_and_delete(
+            message,
+            formatter._t["renew_not_enough"].format(
+                cost=rc.cost,
+                score_word=p.pluralize(rc.cost),
+                balance=result.current_balance,
+                score_word_balance=p.pluralize(result.current_balance),
+            ),
+        )
+        return
+
+    # Сбрасываем лимиты и фиксируем использование
+    await store.renew_game_limits(user_id, chat_id)
+    await store.renew_daily_increment(user_id, chat_id)
+
+    await reply_and_delete(
+        message,
+        formatter._t["renew_success"].format(
+            cost=rc.cost,
+            score_word=p.pluralize(rc.cost),
+            balance=result.new_balance,
+            score_word_balance=p.pluralize(result.new_balance),
+        ),
+        parse_mode=ParseMode.HTML,
+        link_preview_options=NO_PREVIEW,
+    )

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -87,5 +87,6 @@ system:
   auto_delete_seconds: 120        # через сколько секунд удалять служебные сообщения
   history_page_size: 30           # строк на страницу в /history
 
-# Лимиты блекджека
-# (max_bet и min_bet уже есть в blackjack, добавляем rate limiting)
+renew:
+  cost: 100           # стоимость одного /renew
+  daily_limit: 2      # сколько раз в сутки можно использовать /renew

--- a/configs/messages.yaml
+++ b/configs/messages.yaml
@@ -78,3 +78,6 @@ protect_extended: "🛡 Защита продлена до {until}. Списан
 slots_cooldown: "⏳ Следующий спин доступен через {minutes} мин."
 mute_daily_limit: "🚫 Сегодня уже выдано {count} из {limit} мутов. Лимит исчерпан."
 mute_target_cooldown: "⏳ Ты недавно уже мутил {target}. Подожди {hours} ч."
+renew_not_enough: "Недостаточно баллов. Нужно: {cost} {score_word}, у вас: {balance} {score_word_balance}."
+renew_daily_limit: "🚫 Сегодня уже использовал /renew {count} из {limit} раз. Лимит исчерпан."
+renew_success: "🔄 Лимиты игр сброшены за {cost} {score_word}. Баланс: {balance} {score_word_balance}.\n<i>Слоты и блекджек снова доступны.</i>"


### PR DESCRIPTION
- /renew resets slots cooldown, slots daily counter, and BJ sliding window
- Costs 100 kirchiks per use, limited to 2 times per day
- Tracks usage in Redis (renew:daily: key, 24h TTL)
- Added RenewConfig to AppConfig and renew: section to config.yaml
- Added renew_* messages to messages.yaml