### PR TITLE
feat: auto-delete all bot messages after games/commands complete

### DIFF
--- a/bot/infrastructure/dice_loop.py
+++ b/bot/infrastructure/dice_loop.py
@@ -9,10 +9,12 @@ from datetime import datetime
 from aiogram import Bot
 
 from bot.domain.tz import TZ_MSK
+from bot.presentation.utils import schedule_delete, schedule_delete_id
 
 logger = logging.getLogger(__name__)
 
 _DICE_EMOJI = "🎲"
+_GAME_DELETE_DELAY = 30  # секунд после завершения игры
 
 
 async def dice_loop(bot: Bot, container) -> None:
@@ -47,19 +49,23 @@ async def _resolve_game(bot: Bot, game, container) -> None:
         async with container() as scope:
             service = await scope.get(DiceService)
             await service.finish(game.id, {})
-        await bot.send_message(game.chat_id, "🎲 Игра в кости отменена: нет участников.")
-        await _remove_join_button(bot, game.chat_id, game.message_id)
+        cancel_msg = await bot.send_message(game.chat_id, "🎲 Игра в кости отменена: нет участников.")
+        schedule_delete(bot, cancel_msg, delay=_GAME_DELETE_DELAY)
+        await _remove_lobby(bot, game.chat_id, game.message_id)
         return
+
+    # Объявляем начало бросков
+    announce_msg = await bot.send_message(game.chat_id, "🎲 Бросаем кости!")
+    schedule_delete(bot, announce_msg, delay=_GAME_DELETE_DELAY)
 
     # Бросаем кости за каждого участника
     dice_results: dict[int, int] = {}
-
-    await bot.send_message(game.chat_id, "🎲 Бросаем кости!")
 
     for user_id in participants:
         try:
             msg = await bot.send_dice(chat_id=game.chat_id, emoji=_DICE_EMOJI)
             dice_results[user_id] = msg.dice.value  # type: ignore[union-attr]
+            schedule_delete(bot, msg, delay=_GAME_DELETE_DELAY)
             await asyncio.sleep(0.5)
         except Exception:
             logger.warning("Failed to send dice for user %d in game %d", user_id, game.id)
@@ -75,7 +81,7 @@ async def _resolve_game(bot: Bot, game, container) -> None:
         return
 
     await _post_dice_results(bot, result, pluralizer)
-    await _remove_join_button(bot, game.chat_id, game.message_id)
+    await _remove_lobby(bot, game.chat_id, game.message_id)
 
 
 async def _post_dice_results(bot: Bot, result, pluralizer) -> None:
@@ -122,10 +128,12 @@ async def _post_dice_results(bot: Bot, result, pluralizer) -> None:
             f"💰 Приз: <b>{result.prize_per_winner} {score_word}</b> каждому"
         )
 
-    await bot.send_message(chat_id, "\n".join(lines), parse_mode="HTML")
+    result_msg = await bot.send_message(chat_id, "\n".join(lines), parse_mode="HTML")
+    schedule_delete(bot, result_msg, delay=_GAME_DELETE_DELAY)
 
 
-async def _remove_join_button(bot: Bot, chat_id: int, message_id: int | None) -> None:
+async def _remove_lobby(bot: Bot, chat_id: int, message_id: int | None) -> None:
+    """Убирает кнопку у лобби-сообщения и планирует его удаление."""
     if not message_id:
         return
     try:
@@ -136,3 +144,4 @@ async def _remove_join_button(bot: Bot, chat_id: int, message_id: int | None) ->
         )
     except Exception:
         pass
+    schedule_delete_id(bot, chat_id, message_id, delay=_GAME_DELETE_DELAY)

--- a/bot/infrastructure/redis_store.py
+++ b/bot/infrastructure/redis_store.py
@@ -251,6 +251,7 @@ class RedisStore:
                 "losers_count": losers_count,
                 "ends_at": ends_at,
                 "participants": [],
+                "message_id": 0,
             }
         )
         ttl = int(ends_at - time.time()) + 300
@@ -298,6 +299,17 @@ class RedisStore:
         if raw is None:
             return None
         return json.loads(raw)
+
+    async def mute_roulette_set_message_id(self, chat_id: int, roulette_id: str, message_id: int) -> None:
+        """Сохранить message_id лобби-сообщения рулетки."""
+        key = self._mg_key(chat_id, roulette_id)
+        raw = await self._r.get(key)
+        if raw is None:
+            return
+        data = json.loads(raw)
+        data["message_id"] = message_id
+        ttl = await self._r.ttl(key)
+        await self._r.set(key, json.dumps(data), ex=max(ttl, 60))
 
     async def mute_roulette_count(self, chat_id: int, roulette_id: str) -> int:
         key = self._mg_key(chat_id, roulette_id)

--- a/bot/presentation/handlers/blackjack.py
+++ b/bot/presentation/handlers/blackjack.py
@@ -26,7 +26,7 @@ from bot.application.score_service import ScoreService
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter
 from bot.infrastructure.redis_store import RedisStore
-from bot.presentation.utils import NO_PREVIEW, schedule_delete
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete, schedule_delete
 
 _WIN_RESULTS = {GameResult.PLAYER_WIN, GameResult.DEALER_BUST, GameResult.PLAYER_BLACKJACK}
 
@@ -136,7 +136,7 @@ async def cmd_help_bj(
         "Удачи! 🍀"
     )
 
-    await message.reply(text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
+    await reply_and_delete(message, text, parse_mode=ParseMode.HTML, link_preview_options=NO_PREVIEW)
 
 
 # ── /bj <ставка> ────────────────────────────────────────────────
@@ -161,7 +161,7 @@ async def cmd_blackjack(
     chat_id = message.chat.id
 
     if await store.bj_exists(user_id, chat_id):
-        await message.reply("У тебя уже есть активная игра. Доиграй текущую!")
+        await reply_and_delete(message, "У тебя уже есть активная игра. Доиграй текущую!")
         return
 
     # Sliding window
@@ -176,7 +176,7 @@ async def cmd_blackjack(
     if wait is not None:
         total = int(wait)
         mins, secs = divmod(total, 60)
-        await message.reply(f"⏳ Лимит: {bjc.max_games_per_window} игр в час. Следующая игра через {mins}м {secs}с.")
+        await reply_and_delete(message, f"⏳ Лимит: {bjc.max_games_per_window} игр в час. Следующая игра через {mins}м {secs}с.")
         return
 
     # Парсим ставку
@@ -184,7 +184,8 @@ async def cmd_blackjack(
     max_bet = bjc.max_bet
 
     if not command.args:
-        await message.reply(
+        await reply_and_delete(
+            message,
             f"Использование: /bj &lt;ставка&gt;\nСтавка: от {min_bet} до {max_bet} {formatter._p.pluralize(max_bet)}.",
             parse_mode=ParseMode.HTML,
         )
@@ -193,17 +194,17 @@ async def cmd_blackjack(
     try:
         bet = int(command.args.strip())
     except ValueError:
-        await message.reply("Ставка должна быть числом.")
+        await reply_and_delete(message, "Ставка должна быть числом.")
         return
 
     if bet < min_bet or bet > max_bet:
-        await message.reply(f"Ставка: от {min_bet} до {max_bet} {formatter._p.pluralize(max_bet)}.")
+        await reply_and_delete(message, f"Ставка: от {min_bet} до {max_bet} {formatter._p.pluralize(max_bet)}.")
         return
 
     # Проверяем баланс
     score = await score_service.get_score(user_id, chat_id)
     if score.value < bet:
-        await message.reply(f"Недостаточно баллов. У тебя: {score.value} {formatter._p.pluralize(score.value)}.")
+        await reply_and_delete(message, f"Недостаточно баллов. У тебя: {score.value} {formatter._p.pluralize(score.value)}.")
         return
 
     # Записываем игру в sliding window и создаём раунд

--- a/bot/presentation/handlers/dice.py
+++ b/bot/presentation/handlers/dice.py
@@ -19,6 +19,7 @@ from bot.domain.entities import User
 from bot.domain.pluralizer import ScorePluralizer
 from bot.domain.tz import TZ_MSK
 from bot.infrastructure.config_loader import AppConfig
+from bot.presentation.utils import reply_and_delete
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,8 @@ async def cmd_dice(
 
     args = (message.text or "").split()[1:]
     if len(args) < 2:
-        await message.answer(
+        await reply_and_delete(
+            message,
             "🎲 <b>Игра в кости</b>\n\n"
             "Использование: <code>/dice &lt;ставка&gt; &lt;время&gt;</code>\n"
             "Пример: <code>/dice 10 2m</code>\n\n"
@@ -71,37 +73,40 @@ async def cmd_dice(
         if bet <= 0:
             raise ValueError
     except ValueError:
-        await message.answer("❌ Ставка должна быть положительным числом.")
+        await reply_and_delete(message, "❌ Ставка должна быть положительным числом.")
         return
 
     if bet < config.dice.min_bet:
         sw = pluralizer.pluralize(config.dice.min_bet)
-        await message.answer(f"❌ Минимальная ставка: {config.dice.min_bet} {sw}.")
+        await reply_and_delete(message, f"❌ Минимальная ставка: {config.dice.min_bet} {sw}.")
         return
 
     if bet > config.dice.max_bet:
         sw = pluralizer.pluralize(config.dice.max_bet)
-        await message.answer(f"❌ Максимальная ставка: {config.dice.max_bet} {sw}.")
+        await reply_and_delete(message, f"❌ Максимальная ставка: {config.dice.max_bet} {sw}.")
         return
 
     # Парсим время ожидания
     wait_seconds = parse_duration(args[1])
     if wait_seconds is None or wait_seconds <= 0:
-        await message.answer(
+        await reply_and_delete(
+            message,
             "❌ Неверный формат времени. Примеры: <code>30s</code>, <code>1m</code>, <code>2m30s</code>",
             parse_mode="HTML",
         )
         return
 
     if wait_seconds < config.dice.min_wait_seconds:
-        await message.answer(
-            f"❌ Минимальное время ожидания: {format_duration(config.dice.min_wait_seconds)}."
+        await reply_and_delete(
+            message,
+            f"❌ Минимальное время ожидания: {format_duration(config.dice.min_wait_seconds)}.",
         )
         return
 
     if wait_seconds > config.dice.max_wait_seconds:
-        await message.answer(
-            f"❌ Максимальное время ожидания: {format_duration(config.dice.max_wait_seconds)}."
+        await reply_and_delete(
+            message,
+            f"❌ Максимальное время ожидания: {format_duration(config.dice.max_wait_seconds)}.",
         )
         return
 
@@ -123,14 +128,15 @@ async def cmd_dice(
     )
 
     if result.user_already_in_game:
-        await message.answer("❌ Ты уже участвуешь в активной игре в этом чате. Дождись её завершения.")
+        await reply_and_delete(message, "❌ Ты уже участвуешь в активной игре в этом чате. Дождись её завершения.")
         return
 
     if result.not_enough or result.game is None:
         sw = pluralizer.pluralize(bet)
         score_word_many = pluralizer.pluralize(0)  # форма для "много"
-        await message.answer(
-            f"❌ Недостаточно {score_word_many}. Нужно: {bet} {sw}."
+        await reply_and_delete(
+            message,
+            f"❌ Недостаточно {score_word_many}. Нужно: {bet} {sw}.",
         )
         return
 

--- a/bot/presentation/handlers/giveaway.py
+++ b/bot/presentation/handlers/giveaway.py
@@ -28,6 +28,7 @@ from bot.domain.pluralizer import ScorePluralizer
 from bot.domain.tz import TZ_MSK
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.redis_store import RedisStore
+from bot.presentation.utils import reply_and_delete, schedule_delete, schedule_delete_id
 
 logger = logging.getLogger(__name__)
 
@@ -90,12 +91,13 @@ async def cmd_giveaway(
     pluralizer: FromDishka[ScorePluralizer],
 ) -> None:
     if not is_admin(message.from_user and message.from_user.username, config.admin.users):
-        await message.answer("⛔ Только администраторы могут создавать розыгрыши.")
+        await reply_and_delete(message, "⛔ Только администраторы могут создавать розыгрыши.")
         return
 
     args = (message.text or "").split()[1:]
     if not args:
-        await message.answer(
+        await reply_and_delete(
+            message,
             "Использование: <code>/giveaway 500 100 50 [30m|2h]</code>\n"
             "Призовые места через пробел, в конце опционально — время.",
             parse_mode="HTML",
@@ -111,12 +113,12 @@ async def cmd_giveaway(
     prizes: list[int] = []
     for token in args:
         if not token.isdigit() or int(token) <= 0:
-            await message.answer(f"❌ Неверное значение приза: <code>{token}</code>", parse_mode="HTML")
+            await reply_and_delete(message, f"❌ Неверное значение приза: <code>{token}</code>", parse_mode="HTML")
             return
         prizes.append(int(token))
 
     if not prizes:
-        await message.answer("❌ Укажи хотя бы один приз.")
+        await reply_and_delete(message, "❌ Укажи хотя бы один приз.")
         return
 
     giveaway = await service.create(
@@ -149,7 +151,7 @@ async def cmd_giveaway_end(
     pluralizer: FromDishka[ScorePluralizer],
 ) -> None:
     if not is_admin(message.from_user and message.from_user.username, config.admin.users):
-        await message.answer("⛔ Только администраторы могут завершать розыгрыши.")
+        await reply_and_delete(message, "⛔ Только администраторы могут завершать розыгрыши.")
         return
 
     args = (message.text or "").split()[1:]
@@ -160,7 +162,7 @@ async def cmd_giveaway_end(
     else:
         active = await service.get_active_in_chat(message.chat.id)
         if not active:
-            await message.answer("Нет активных розыгрышей.")
+            await reply_and_delete(message, "Нет активных розыгрышей.")
             return
         if len(active) == 1:
             giveaway_id = active[0].id
@@ -169,12 +171,12 @@ async def cmd_giveaway_end(
             for g in active:
                 prizes_str = " / ".join(f"{p} {pluralizer.pluralize(p)}" for p in g.prizes)
                 lines.append(f"<code>/giveaway_end {g.id}</code> — {prizes_str}")
-            await message.answer("\n".join(lines), parse_mode="HTML")
+            await reply_and_delete(message, "\n".join(lines), parse_mode="HTML")
             return
 
     result = await service.finish(giveaway_id)
     if result is None:
-        await message.answer("❌ Розыгрыш не найден или уже завершён.")
+        await reply_and_delete(message, "❌ Розыгрыш не найден или уже завершён.")
         return
 
     await _post_results(bot, result.giveaway, result.winners, result.participants_count, pluralizer)
@@ -243,7 +245,8 @@ async def _post_results(
             lines.append(f"{medal} {mention} — +{prize_str}")
         text = "\n".join(lines)
 
-    await bot.send_message(giveaway.chat_id, text, parse_mode="HTML")
+    result_msg = await bot.send_message(giveaway.chat_id, text, parse_mode="HTML")
+    schedule_delete(bot, result_msg, delay=30)
 
     if giveaway.message_id:
         try:
@@ -254,6 +257,7 @@ async def _post_results(
             )
         except Exception:
             pass
+        schedule_delete_id(bot, giveaway.chat_id, giveaway.message_id, delay=30)
 
 
 # ─── Мут-рулетка ────────────────────────────────────────────────────────────
@@ -281,14 +285,15 @@ async def cmd_mute_roulette(
     store: FromDishka[RedisStore],
 ) -> None:
     if not is_admin(message.from_user and message.from_user.username, config.admin.users):
-        await message.answer("Только администраторы могут запускать мут-гивэвей.")
+        await reply_and_delete(message, "Только администраторы могут запускать мут-гивэвей.")
         return
 
     args = (message.text or "").split()[1:]
     # /mutegiveaway <время_мута> <кол-во_проигравших> <время_сбора>
     # /mutegiveaway 10m 2 5m
     if len(args) < 3:
-        await message.answer(
+        await reply_and_delete(
+            message,
             "Использование: <code>/mutegiveaway &lt;мут&gt; &lt;кол-во&gt; &lt;сбор&gt;</code>\n"
             "Пример: <code>/mutegiveaway 10m 2 5m</code>\n"
             "= мут 10 минут, 2 проигравших, сбор участников 5 минут.",
@@ -298,7 +303,7 @@ async def cmd_mute_roulette(
 
     mute_secs = parse_duration(args[0])
     if mute_secs is None or mute_secs < 60:
-        await message.answer("Неверное время мута (мин. 1m).")
+        await reply_and_delete(message, "Неверное время мута (мин. 1m).")
         return
 
     try:
@@ -306,12 +311,12 @@ async def cmd_mute_roulette(
         if losers_count < 1:
             raise ValueError
     except ValueError:
-        await message.answer("Кол-во проигравших должно быть >= 1.")
+        await reply_and_delete(message, "Кол-во проигравших должно быть >= 1.")
         return
 
     collect_secs = parse_duration(args[2])
     if collect_secs is None or collect_secs < 30:
-        await message.answer("Время сбора минимум 30 секунд.")
+        await reply_and_delete(message, "Время сбора минимум 30 секунд.")
         return
 
     chat_id = message.chat.id
@@ -337,7 +342,8 @@ async def cmd_mute_roulette(
         f"🆔 ID: <code>{roulette_id}</code>\n\n"
         f"Жми кнопку, если не трус!"
     )
-    await message.answer(text, parse_mode="HTML", reply_markup=_mute_roulette_kb(chat_id, roulette_id, 0))
+    sent = await message.answer(text, parse_mode="HTML", reply_markup=_mute_roulette_kb(chat_id, roulette_id, 0))
+    await store.mute_roulette_set_message_id(chat_id, roulette_id, sent.message_id)
 
 
 @router.callback_query(F.data.startswith("mutegiveaway:join:"))
@@ -375,7 +381,7 @@ async def cmd_mute_roulette_end(
     mute_service: FromDishka[MuteService],
 ) -> None:
     if not is_admin(message.from_user and message.from_user.username, config.admin.users):
-        await message.answer("Только администраторы.")
+        await reply_and_delete(message, "Только администраторы.")
         return
 
     chat_id = message.chat.id
@@ -386,7 +392,7 @@ async def cmd_mute_roulette_end(
     if roulette_id is None:
         active = await store.mute_roulette_list(chat_id)
         if not active:
-            await message.answer("Нет активных мут-гивэвеев.")
+            await reply_and_delete(message, "Нет активных мут-гивэвеев.")
             return
         if len(active) == 1:
             roulette_id = active[0][0]
@@ -399,12 +405,12 @@ async def cmd_mute_roulette_end(
                     f"проигравших {data['losers_count']}, "
                     f"участников {len(data['participants'])}"
                 )
-            await message.answer("\n".join(lines), parse_mode="HTML")
+            await reply_and_delete(message, "\n".join(lines), parse_mode="HTML")
             return
 
     data = await store.mute_roulette_delete(chat_id, roulette_id)
     if data is None:
-        await message.answer("❌ Мут-гивэвей не найден или уже завершён.")
+        await reply_and_delete(message, "❌ Мут-гивэвей не найден или уже завершён.")
         return
 
     await _finish_mute_roulette(bot, chat_id, data, mute_service)
@@ -422,8 +428,13 @@ async def _finish_mute_roulette(
     mute_minutes = data["mute_minutes"]
     creator_id = data["creator_id"]
 
+    lobby_message_id: int = data.get("message_id", 0)
+
     if not participants:
-        await bot.send_message(chat_id, "🎰 Мут-гивэвей завершён, но никто не участвовал.")
+        result_msg = await bot.send_message(chat_id, "🎰 Мут-гивэвей завершён, но никто не участвовал.")
+        schedule_delete(bot, result_msg, delay=30)
+        if lobby_message_id:
+            schedule_delete_id(bot, chat_id, lobby_message_id, delay=30)
         return
 
     losers = random.sample(participants, min(losers_count, len(participants)))
@@ -502,4 +513,7 @@ async def _finish_mute_roulette(
             logger.exception("Failed to mute %d in roulette", user_id)
             lines.append(f"⚠️ {name} — не удалось замутить")
 
-    await bot.send_message(chat_id, "\n".join(lines), parse_mode="HTML")
+    result_msg = await bot.send_message(chat_id, "\n".join(lines), parse_mode="HTML")
+    schedule_delete(bot, result_msg, delay=30)
+    if lobby_message_id:
+        schedule_delete_id(bot, chat_id, lobby_message_id, delay=30)

--- a/bot/presentation/handlers/slots.py
+++ b/bot/presentation/handlers/slots.py
@@ -17,7 +17,7 @@ from bot.application.score_service import ScoreService
 from bot.infrastructure.config_loader import AppConfig
 from bot.infrastructure.message_formatter import MessageFormatter
 from bot.infrastructure.redis_store import RedisStore
-from bot.presentation.utils import NO_PREVIEW, schedule_delete
+from bot.presentation.utils import NO_PREVIEW, reply_and_delete, schedule_delete
 
 logger = logging.getLogger(__name__)
 router = Router(name="slots")
@@ -84,7 +84,8 @@ async def cmd_slots(
             if sc.cooldown_minutes > 0
             else ""
         )
-        await message.reply(
+        await reply_and_delete(
+            message,
             f"🎰 <b>Слоты</b>\n\n"
             f"Использование: /slots &lt;ставка&gt;\n"
             f"Ставка: от {sc.min_bet} до {sc.max_bet} {p.pluralize(sc.max_bet)}"
@@ -102,11 +103,11 @@ async def cmd_slots(
     try:
         bet = int(command.args.strip())
     except ValueError:
-        await message.reply("Ставка должна быть числом.")
+        await reply_and_delete(message, "Ставка должна быть числом.")
         return
 
     if bet < sc.min_bet or bet > sc.max_bet:
-        await message.reply(f"Ставка: от {sc.min_bet} до {sc.max_bet} {p.pluralize(sc.max_bet)}.")
+        await reply_and_delete(message, f"Ставка: от {sc.min_bet} до {sc.max_bet} {p.pluralize(sc.max_bet)}.")
         return
 
     # Проверяем кулдаун перед списанием ставки
@@ -122,14 +123,15 @@ async def cmd_slots(
                 remaining = math.ceil((cooldown_seconds - elapsed) / 60)
             else:
                 remaining = sc.cooldown_minutes
-            await message.reply(
+            await reply_and_delete(
+                message,
                 formatter._t["slots_cooldown"].format(minutes=remaining),
             )
             return
 
     score = await score_service.get_score(user_id, chat_id)
     if score.value < bet:
-        await message.reply(f"Недостаточно баллов. У тебя: {score.value} {p.pluralize(score.value)}.")
+        await reply_and_delete(message, f"Недостаточно баллов. У тебя: {score.value} {p.pluralize(score.value)}.")
         return
 
     # Устанавливаем кулдаун сразу после всех проверок
@@ -177,4 +179,4 @@ async def cmd_slots(
         parse_mode=ParseMode.HTML,
         link_preview_options=NO_PREVIEW,
     )
-    schedule_delete(bot, message, result_msg, delay=30)
+    schedule_delete(bot, message, dice_msg, result_msg, delay=30)

--- a/bot/presentation/utils.py
+++ b/bot/presentation/utils.py
@@ -32,6 +32,11 @@ def schedule_delete(bot: Bot, *messages: Message, delay: int = 120) -> None:
         asyncio.create_task(_delete_after(bot, msg.chat.id, msg.message_id, delay))
 
 
+def schedule_delete_id(bot: Bot, chat_id: int, message_id: int, delay: int = 120) -> None:
+    """Планирует удаление сообщения по chat_id и message_id через delay секунд."""
+    asyncio.create_task(_delete_after(bot, chat_id, message_id, delay))
+
+
 async def reply_and_delete(message: Message, *args: Any, delay: int = AUTO_DELETE_DELAY, **kwargs: Any) -> Message:
     """Отправляет reply и планирует его удаление через delay секунд."""
     reply = await message.reply(*args, **kwargs)


### PR DESCRIPTION
- utils.py: add schedule_delete_id() helper for deletion by raw IDs
- blackjack.py, slots.py, dice.py: replace error message.reply() with reply_and_delete() for 60s auto-delete; dice_msg in slots now also scheduled for 30s deletion after game end
- dice_loop.py: rename _remove_join_button → _remove_lobby; schedule deletion of lobby, announce, dice-roll and result messages 30s after game completion; add _GAME_DELETE_DELAY = 30 constant
- giveaway.py: replace all error message.answer() with reply_and_delete(); schedule deletion of result + lobby messages 30s after giveaway/roulette completes; store mute-roulette lobby message_id via new Redis method
- redis_store.py: add message_id field to mute_roulette_create data; add mute_roulette_set_message_id() method