### PR TITLE
feat: бот ставит только положительные авто-реакции

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -79,7 +79,7 @@ llm:
 auto_react:
   enabled: true
   probability: 0.05   # 5% — каждое 20-е сообщение в среднем
-  positive_only: false # только 👍❤️🔥 итд, без 💩👎
+  positive_only: true
 # Системные интервалы и параметры
 system:
   cleanup_interval_hours: 6       # как часто удалять устаревшие события


### PR DESCRIPTION
Включён флаг positive_only в auto_react — бот больше не ставит автоматически негативные реакции (👎💩🤡) на сообщения пользователей. Пользователи по-прежнему могут ставить негативные реакции вручную.