### PR TITLE
perf: централизованная очередь удалений + частичный возврат ставки BJ

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -29,6 +29,7 @@ from bot.presentation.handlers.transfer import router as transfer_router
 from bot.presentation.middlewares.auto_delete import AutoDeleteCommandMiddleware
 from bot.presentation.middlewares.chat_context import ChatContextMiddleware
 from bot.presentation.middlewares.track_message import TrackMessageMiddleware
+from bot.presentation.utils import delete_loop
 
 logging.basicConfig(
     level=logging.INFO,
@@ -105,7 +106,7 @@ async def mute_roulette_loop(container, bot: Bot) -> None:
 
 
 async def bj_cleanup_loop(container, bot: Bot) -> None:
-    """Фоновая задача: возврат ставки по истёкшим играм блекджека."""
+    """Фоновая задача: закрывает истёкшие игры блекджека (возвращает половину ставки)."""
     from bot.application.score_service import ScoreService
     from bot.infrastructure.redis_store import RedisStore
 
@@ -119,13 +120,18 @@ async def bj_cleanup_loop(container, bot: Bot) -> None:
                     user_id = data["player_id"]
                     chat_id = data["chat_id"]
                     bet = data["bet"]
+                    refund = bet // 2
                     message_id = data.get("message_id", 0)
-                    logger.info("BJ timeout: returning %d to user %d in chat %d", bet, user_id, chat_id)
-                    await score_service.add_score(user_id, chat_id, bet, admin_id=user_id)
+                    logger.info(
+                        "BJ timeout: refunding %d/%d to user %d in chat %d",
+                        refund, bet, user_id, chat_id,
+                    )
+                    if refund > 0:
+                        await score_service.add_score(user_id, chat_id, refund, admin_id=user_id)
                     if message_id:
                         try:
                             await bot.edit_message_text(
-                                "⏰ Время вышло! Ставка возвращена.",
+                                f"⏰ Время вышло! Возвращено {refund} из {bet}.",
                                 chat_id=chat_id,
                                 message_id=message_id,
                                 reply_markup=None,
@@ -194,6 +200,7 @@ async def main() -> None:
     dice_task = asyncio.create_task(dice_loop(bot, container))
     mute_roulette_task = asyncio.create_task(mute_roulette_loop(container, bot))
     bj_cleanup_task = asyncio.create_task(bj_cleanup_loop(container, bot))
+    delete_task = asyncio.create_task(delete_loop(bot))
 
     logger.info("Bot starting…")
     try:
@@ -208,6 +215,7 @@ async def main() -> None:
         dice_task.cancel()
         mute_roulette_task.cancel()
         bj_cleanup_task.cancel()
+        delete_task.cancel()
         if tg_log_handler:
             tg_log_handler.stop()
         await container.close()

--- a/bot/presentation/utils.py
+++ b/bot/presentation/utils.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import heapq
 import logging
+import time
 from typing import Any
 
 from aiogram import Bot
@@ -17,24 +19,45 @@ NO_PREVIEW = LinkPreviewOptions(is_disabled=True)
 # Задержка автоудаления для обычных (не игровых) ответов бота
 AUTO_DELETE_DELAY = 60
 
-
-async def _delete_after(bot: Bot, chat_id: int, message_id: int, delay: int) -> None:
-    await asyncio.sleep(delay)
-    try:
-        await bot.delete_message(chat_id, message_id)
-    except Exception:
-        pass
+# Централизованная очередь удалений: (delete_at, chat_id, message_id)
+# Используется heap для O(log n) вставки и извлечения минимума.
+# Безопасно в asyncio (однопоточная среда) — синхронизация не нужна.
+_delete_heap: list[tuple[float, int, int]] = []
 
 
 def schedule_delete(bot: Bot, *messages: Message, delay: int = 120) -> None:
     """Планирует удаление одного или нескольких сообщений через delay секунд."""
+    t = time.monotonic() + delay
     for msg in messages:
-        asyncio.create_task(_delete_after(bot, msg.chat.id, msg.message_id, delay))
+        heapq.heappush(_delete_heap, (t, msg.chat.id, msg.message_id))
 
 
 def schedule_delete_id(bot: Bot, chat_id: int, message_id: int, delay: int = 120) -> None:
     """Планирует удаление сообщения по chat_id и message_id через delay секунд."""
-    asyncio.create_task(_delete_after(bot, chat_id, message_id, delay))
+    heapq.heappush(_delete_heap, (time.monotonic() + delay, chat_id, message_id))
+
+
+async def delete_loop(bot: Bot) -> None:
+    """Фоновый воркер: удаляет сообщения из очереди по одному.
+
+    Вместо N параллельных задач (которые одновременно флудят Telegram и
+    провоцируют 429 RetryAfter) используется один цикл с паузой 50 мс
+    между запросами (~20 удалений/сек максимум).
+    """
+    while True:
+        now = time.monotonic()
+        if _delete_heap and _delete_heap[0][0] <= now:
+            _, chat_id, message_id = heapq.heappop(_delete_heap)
+            try:
+                await bot.delete_message(chat_id, message_id)
+            except Exception:
+                pass
+            # Пауза между запросами — не флудим Telegram API
+            await asyncio.sleep(0.05)
+        else:
+            # Ждём до ближайшего запланированного удаления или максимум 2 сек
+            wait = (_delete_heap[0][0] - now) if _delete_heap else 2.0
+            await asyncio.sleep(min(wait, 2.0))
 
 
 async def safe_callback_answer(


### PR DESCRIPTION
utils.py: заменить N параллельных asyncio.create_task на единый delete_loop. Все schedule_delete/schedule_delete_id теперь пишут в min-heap (_delete_heap), воркер обрабатывает удаления по одному с паузой 50 мс — устраняет флуд Telegram API и 429 RetryAfter, из-за которых бот лагал при удалении сообщений.

main.py: при таймауте BJ-игры возвращается половина ставки (bet // 2) вместо полного сгорания; сообщение показывает «Возвращено X из Y».