### PR TITLE
feat: retry middleware для устойчивости к сетевым ошибкам Telegram

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 import os
 
+from aiohttp import ClientTimeout
 from aiogram import Bot, Dispatcher
+from aiogram.client.session.aiohttp import AiohttpSession
 from dishka import make_async_container
 from dishka.integrations.aiogram import setup_dishka
 
@@ -28,6 +30,7 @@ from bot.presentation.handlers.renew import router as renew_router
 from bot.presentation.handlers.transfer import router as transfer_router
 from bot.presentation.middlewares.auto_delete import AutoDeleteCommandMiddleware
 from bot.presentation.middlewares.chat_context import ChatContextMiddleware
+from bot.presentation.middlewares.retry_network import RetryNetworkMiddleware
 from bot.presentation.middlewares.track_message import TrackMessageMiddleware
 from bot.presentation.utils import delete_loop
 
@@ -148,7 +151,9 @@ async def main() -> None:
 
     container = make_async_container(AppProvider(), RequestProvider())
 
-    bot = Bot(token=settings.bot_token)
+    # Короткий таймаут: не ждём 60 с на SSL handshake, падаем быстро и идём дальше
+    session = AiohttpSession(timeout=ClientTimeout(total=15, connect=8))
+    bot = Bot(token=settings.bot_token, session=session)
 
     # Мониторинг: отправка логов в Telegram-чат
     tg_log_handler = None
@@ -163,6 +168,12 @@ async def main() -> None:
         logger.info("Telegram log handler enabled (chat_id=%d, level=%s)", settings.log_chat_id, settings.log_level)
 
     dp = Dispatcher()
+
+    # Первым в цепочке — перехватываем сетевые ошибки до любой бизнес-логики
+    retry_mw = RetryNetworkMiddleware()
+    dp.message.outer_middleware(retry_mw)
+    dp.callback_query.outer_middleware(retry_mw)
+    dp.message_reaction.outer_middleware(retry_mw)
 
     dp.message.outer_middleware(ChatContextMiddleware())
     dp.message_reaction.outer_middleware(ChatContextMiddleware())

--- a/bot/presentation/middlewares/retry_network.py
+++ b/bot/presentation/middlewares/retry_network.py
@@ -1,0 +1,50 @@
+"""Middleware: повтор запроса при сетевых ошибках Telegram API."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable
+
+from aiogram import BaseMiddleware
+from aiogram.exceptions import TelegramNetworkError
+from aiogram.types import TelegramObject
+
+logger = logging.getLogger(__name__)
+
+_MAX_ATTEMPTS = 3
+_DELAYS = (0.5, 2.0)  # пауза перед 2-й и 3-й попыткой (секунды)
+
+
+class RetryNetworkMiddleware(BaseMiddleware):
+    """Повторяет обработку апдейта при TelegramNetworkError.
+
+    До _MAX_ATTEMPTS попыток с экспоненциальными паузами.
+    После исчерпания попыток — тихо пропускает апдейт (не роняет бота).
+    """
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        last_exc: TelegramNetworkError | None = None
+
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                return await handler(event, data)
+            except TelegramNetworkError as e:
+                last_exc = e
+                if attempt < _MAX_ATTEMPTS - 1:
+                    delay = _DELAYS[attempt]
+                    logger.warning(
+                        "TelegramNetworkError (attempt %d/%d), retry in %.1fs: %s",
+                        attempt + 1, _MAX_ATTEMPTS, delay, e,
+                    )
+                    await asyncio.sleep(delay)
+
+        logger.error(
+            "TelegramNetworkError after %d attempts, dropping update: %s",
+            _MAX_ATTEMPTS, last_exc,
+        )
+        return None


### PR DESCRIPTION
RetryNetworkMiddleware перехватывает TelegramNetworkError на уровне outer_middleware для message, callback_query и message_reaction. До 3 попыток с паузами 0.5 с и 2.0 с — после исчерпания апдейт тихо дропается без краша бота. Таймаут сессии снижен до 15 с / 8 с (connect), чтобы не блокировать event loop на 60 с при недоступности API.