### PR TITLE
feat: burst reward — тихое начисление за активность в чате

### DIFF
--- a/bot/application/score_service.py
+++ b/bot/application/score_service.py
@@ -29,6 +29,7 @@ SPECIAL_EMOJI = {
     "tag": "🏷",
     "transfer": "💸",
     "protect": "🛡",
+    "burst": "💬",
 }
 
 
@@ -348,6 +349,14 @@ class ScoreService:
             sender_balance=sender_new,
             receiver_balance=receiver_new,
         )
+
+    async def award_burst(self, user_id: int, chat_id: int, reward: int) -> int:
+        """Тихое начисление за burst-активность. Возвращает новый баланс."""
+        new_value = await self._score_repo.add_delta(user_id, chat_id, reward)
+        await self._save_special_event(
+            user_id, user_id, chat_id, reward, SPECIAL_EMOJI["burst"],
+        )
+        return new_value
 
     async def _save_special_event(
         self,

--- a/bot/infrastructure/config_loader.py
+++ b/bot/infrastructure/config_loader.py
@@ -126,6 +126,15 @@ class DiceConfig(_BaseConfig):
     max_wait_seconds: int = 900
 
 
+class BurstConfig(_BaseConfig):
+    enabled: bool = False
+    messages_required: int = 8
+    window_minutes: int = 20
+    min_length: int = 15
+    reward: int = 15
+    cooldown_hours: int = 4
+
+
 class SystemConfig(_BaseConfig):
     """Системные интервалы и технические параметры."""
 
@@ -221,6 +230,7 @@ class AppConfig(_BaseConfig):
     slots: SlotsConfig = SlotsConfig()
     dice: DiceConfig = DiceConfig()
     llm: LlmConfig = LlmConfig()
+    burst: BurstConfig = BurstConfig()
     system: SystemConfig = SystemConfig()
     renew: RenewConfig = RenewConfig()
     wordgame: WordgameConfig = WordgameConfig()

--- a/bot/infrastructure/redis_store.py
+++ b/bot/infrastructure/redis_store.py
@@ -20,6 +20,8 @@ _SLOTS_LAST = "slots:last:"  # slots:last:{user_id}:{chat_id}
 _JACKPOT = "slots:jackpot:"  # slots:jackpot:{chat_id}
 _OWNER_MUTE = "owner_mute:"  # owner_mute:{chat_id}:{user_id}
 _GIVEAWAY_PERIOD = "giveaway_period:"  # giveaway_period:{chat_id}:{gp_id}
+_BURST_WINDOW = "burst:win:"  # burst:win:{user_id}:{chat_id} (sorted set)
+_BURST_COOLDOWN = "burst:cd:"  # burst:cd:{user_id}:{chat_id}
 
 
 def _serialize_round(
@@ -262,6 +264,41 @@ class RedisStore:
         key = f"{_JACKPOT}{chat_id}"
         raw = await self._r.get(key)
         return int(raw or 0)
+
+    # ── Burst: скользящее окно сообщений + кулдаун ─────────────
+
+    async def burst_cooldown_active(self, user_id: int, chat_id: int) -> bool:
+        """True если кулдаун активен (награда недавно выдана)."""
+        key = f"{_BURST_COOLDOWN}{user_id}:{chat_id}"
+        return bool(await self._r.exists(key))
+
+    async def burst_add_message(
+        self,
+        user_id: int,
+        chat_id: int,
+        window_seconds: int,
+    ) -> int:
+        """Добавить timestamp в скользящее окно. Возвращает кол-во сообщений в окне."""
+        key = f"{_BURST_WINDOW}{user_id}:{chat_id}"
+        now = time.time()
+        cutoff = now - window_seconds
+
+        pipe = self._r.pipeline()
+        pipe.zremrangebyscore(key, 0, cutoff)
+        pipe.zadd(key, {str(now): now})
+        pipe.zcard(key)
+        pipe.expire(key, window_seconds + 60)
+        results = await pipe.execute()
+        return results[2]  # zcard result
+
+    async def burst_set_cooldown(self, user_id: int, chat_id: int, cooldown_seconds: int) -> None:
+        """Поставить кулдаун и очистить окно."""
+        cd_key = f"{_BURST_COOLDOWN}{user_id}:{chat_id}"
+        win_key = f"{_BURST_WINDOW}{user_id}:{chat_id}"
+        pipe = self._r.pipeline()
+        pipe.set(cd_key, "1", ex=cooldown_seconds)
+        pipe.delete(win_key)
+        await pipe.execute()
 
     # ── Мут-гивэвей ──────────────────────────────────────────────
     # Ключ: mutegiveaway:{chat_id}:{roulette_id}

--- a/bot/presentation/middlewares/track_message.py
+++ b/bot/presentation/middlewares/track_message.py
@@ -16,6 +16,7 @@ from bot.domain.entities import User
 from bot.domain.reaction_registry import ReactionRegistry
 from bot.domain.tz import TZ_MSK
 from bot.infrastructure.config_loader import AppConfig
+from bot.infrastructure.redis_store import RedisStore
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,7 @@ class TrackMessageMiddleware(BaseMiddleware):
             )
 
             await self._maybe_react(event, container)
+            await self._maybe_burst(event, container)
 
         return await handler(event, data)
 
@@ -125,3 +127,48 @@ class TrackMessageMiddleware(BaseMiddleware):
             message.message_id,
             result.applied,
         )
+
+    async def _maybe_burst(self, message: Message, container: AsyncContainer) -> None:
+        config = await container.get(AppConfig)
+        cfg = config.burst
+
+        if not cfg.enabled:
+            return
+        if message.from_user is None:
+            return
+        # Боты не участвуют
+        if message.from_user.is_bot:
+            return
+        # Команды не засчитываются
+        if message.text and message.text.startswith("/"):
+            return
+        # Форварды не засчитываются
+        if message.forward_origin is not None:
+            return
+
+        # Текст сообщения (text или caption)
+        text = message.text or message.caption or ""
+        if len(text) < cfg.min_length:
+            return
+
+        user_id = message.from_user.id
+        chat_id = message.chat.id
+
+        store = await container.get(RedisStore)
+
+        # Кулдаун активен — пропускаем
+        if await store.burst_cooldown_active(user_id, chat_id):
+            return
+
+        window_seconds = cfg.window_minutes * 60
+        count = await store.burst_add_message(user_id, chat_id, window_seconds)
+
+        if count >= cfg.messages_required:
+            score_service = await container.get(ScoreService)
+            cooldown_seconds = cfg.cooldown_hours * 3600
+            await store.burst_set_cooldown(user_id, chat_id, cooldown_seconds)
+            new_value = await score_service.award_burst(user_id, chat_id, cfg.reward)
+            logger.debug(
+                "burst: user %d in chat %d awarded %d, new score %d",
+                user_id, chat_id, cfg.reward, new_value,
+            )

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -77,6 +77,14 @@ llm:
   search_max_results: 7         # сколько результатов поиска парсить
 
 
+burst:
+  enabled: true
+  messages_required: 8          # сколько сообщений нужно
+  window_minutes: 20            # за какой период (скользящее окно)
+  min_length: 15                # минимальная длина сообщения (символов)
+  reward: 15                    # награда в кирчиках
+  cooldown_hours: 4             # кулдаун после срабатывания
+
 auto_react:
   enabled: true
   probability: 0.05   # 5% — каждое 20-е сообщение в среднем


### PR DESCRIPTION
Если пользователь отправляет N сообщений за M минут (каждое ≥ T символов), он получает +X кирчиков. После срабатывания — кулдаун на H часов. Все параметры настраиваются в configs/config.yaml секция burst.