### PR TITLE
feat: rename /wordgame → /word и лимит создания игр (3 за 4 часа)

### DIFF
--- a/bot/infrastructure/config_loader.py
+++ b/bot/infrastructure/config_loader.py
@@ -209,6 +209,8 @@ class WordgameConfig(_BaseConfig):
     attempt_cost: int = 1              # баллов за неудачную попытку
     min_word_length: int = 2
     max_word_length: int = 32
+    max_games_per_window: int = 3      # макс. игр за окно
+    game_window_hours: int = 4         # окно лимита в часах
 
 class BugConfig(_BaseConfig):
     """Конфиг для команды /bug — кому отправлять баг-репорты."""

--- a/bot/infrastructure/redis_store.py
+++ b/bot/infrastructure/redis_store.py
@@ -593,6 +593,7 @@ class RedisStore:
     _WG_AWAITING = "wg:awaiting:"
     _WG_GAME     = "wg:game:"
     _WG_CHAT     = "wg:chat:"
+    _WG_RATE     = "wg:rate:"
     _WG_TTL      = 600  # 10 минут на ввод слова создателем
 
     async def wg_pending_create(
@@ -633,6 +634,20 @@ class RedisStore:
 
     async def wg_awaiting_delete(self, user_id: int) -> None:
         await self._r.delete(f"{self._WG_AWAITING}{user_id}")
+
+    async def wg_rate_check(self, user_id: int, max_games: int, window_seconds: int) -> int:
+        """Проверить сколько игр создал пользователь за окно. Не инкрементирует."""
+        key = f"{self._WG_RATE}{user_id}"
+        now = time.time()
+        await self._r.zremrangebyscore(key, 0, now - window_seconds)
+        return await self._r.zcard(key)
+
+    async def wg_rate_record(self, user_id: int, window_seconds: int) -> None:
+        """Записать факт создания игры."""
+        key = f"{self._WG_RATE}{user_id}"
+        now = time.time()
+        await self._r.zadd(key, {str(now): now})
+        await self._r.expire(key, window_seconds)
 
     async def wg_game_create(self, game) -> None:
         """Сохранить новую активную игру (WordGame)."""

--- a/bot/presentation/handlers/wordgame.py
+++ b/bot/presentation/handlers/wordgame.py
@@ -1,7 +1,7 @@
 """Обработчики игры «Угадайка».
 
 Флоу:
-1. /wordgame <ставка> <время>  — в группе: создаёт игру, пишет создателю в ЛС
+1. /word <ставка> <время>  — в группе: создаёт игру, пишет создателю в ЛС
 2. /start в ЛС — предлагает ввести слово если есть pending
 3. Текст в ЛС — создатель отправляет загаданное слово
 4. Reply на игровое сообщение бота — попытка угадать слово
@@ -108,9 +108,9 @@ def _game_to_raw(game: WordGame) -> dict:
     }
 
 
-# ── /wordgame <ставка> <время> ───────────────────────────────────────────────
+# ── /word <ставка> <время> ───────────────────────────────────────────────
 
-@router.message(Command("wordgame"))
+@router.message(Command("word"))
 @inject
 async def cmd_wordgame(
     message: Message,
@@ -127,9 +127,9 @@ async def cmd_wordgame(
     if len(args) < 2:
         await reply_and_delete(
             message,
-            f"Использование: <code>/wordgame &lt;ставка&gt; &lt;время&gt;</code>\n"
+            f"Использование: <code>/word &lt;ставка&gt; &lt;время&gt;</code>\n"
             f"Ставка: {wg.min_bet}–{wg.max_bet}  |  Время: от 3m до 1h\n\n"
-            f"Пример: <code>/wordgame 50 10m</code>",
+            f"Пример: <code>/word 50 10m</code>",
             parse_mode=ParseMode.HTML,
         )
         return
@@ -169,6 +169,15 @@ async def cmd_wordgame(
         )
         return
 
+    window_secs = wg.game_window_hours * 3600
+    created = await store.wg_rate_check(user_id, wg.max_games_per_window, window_secs)
+    if created >= wg.max_games_per_window:
+        await reply_and_delete(
+            message,
+            f"❌ Лимит: {wg.max_games_per_window} игры за {wg.game_window_hours} ч. Попробуй позже.",
+        )
+        return
+
     await user_repo.upsert(User(
         id=user_id,
         username=message.from_user.username,
@@ -183,6 +192,7 @@ async def cmd_wordgame(
         duration_seconds=duration_secs,
     )
     await store.wg_awaiting_set(user_id, game_id)
+    await store.wg_rate_record(user_id, window_secs)
 
     user_mention = f'<a href="tg://user?id={user_id}">{message.from_user.full_name}</a>'
     bet_str = pluralizer.pluralize(bet)
@@ -232,7 +242,7 @@ async def cmd_start_private(
     game_id = await store.wg_awaiting_get(user_id)
     if game_id is None:
         await message.answer(
-            "Привет! Чтобы начать игру, используй /wordgame в групповом чате."
+            "Привет! Чтобы начать игру, используй /word в групповом чате."
         )
         return
 
@@ -241,7 +251,7 @@ async def cmd_start_private(
         await store.wg_awaiting_delete(user_id)
         await message.answer(
             "❌ Игра устарела (прошло больше 10 мин).\n"
-            "Начни новую командой /wordgame в группе."
+            "Начни новую командой /word в группе."
         )
         return
 
@@ -269,7 +279,7 @@ async def msg_private_word(
     if game_id is None:
         await message.answer(
             "Нет активной игры, ожидающей слово.\n"
-            "Начни командой /wordgame в групповом чате."
+            "Начни командой /word в групповом чате."
         )
         return
 
@@ -287,7 +297,7 @@ async def msg_private_word(
     if pending is None:
         await store.wg_awaiting_delete(user_id)
         await message.answer(
-            "❌ Игра устарела. Начни новую командой /wordgame в группе."
+            "❌ Игра устарела. Начни новую командой /word в группе."
         )
         return
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -130,6 +130,8 @@ wordgame:
   attempt_cost: 1             # баллов за неудачную попытку
   min_word_length: 2
   max_word_length: 16
+  max_games_per_window: 3     # макс. игр за окно
+  game_window_hours: 4        # окно лимита в часах
 
 logging:
   level: "INFO"


### PR DESCRIPTION
- Команда переименована /wordgame → /word во всех хендлерах и текстах
- Добавлен rate limit: макс. 3 игры за 4 часа на пользователя (Redis sorted set)
- Конфиг: max_games_per_window и game_window_hours в секции wordgame