### PR TITLE
fix: передавать все MODERATOR_PERMS при /op промоуте

### DIFF
--- a/bot/presentation/handlers/admin_user.py
+++ b/bot/presentation/handlers/admin_user.py
@@ -153,7 +153,7 @@ async def cmd_op(
         return
     try:
         await message.bot.promote_chat_member(
-            chat_id=message.chat.id, user_id=target.id, can_invite_users=True
+            chat_id=message.chat.id, user_id=target.id, **MODERATOR_PERMS
         )
     except Exception:
         logger.exception("Failed to op user %d", target.id)


### PR DESCRIPTION
Команда /op выдавала пользователю только can_invite_users=True, но сохраняла в БД полный набор MODERATOR_PERMS (6 прав). Это приводило к тому, что /restore пытался восстановить права, которых у пользователя на самом деле не было.